### PR TITLE
Expose Orchestrations, Activites, Middleware in builder

### DIFF
--- a/src/DurableTask.DependencyInjection/src/DefaultTaskHubWorkerBuilder.cs
+++ b/src/DurableTask.DependencyInjection/src/DefaultTaskHubWorkerBuilder.cs
@@ -71,6 +71,19 @@ namespace DurableTask.DependencyInjection
                 throw new InvalidOperationException(Strings.OrchestrationInstanceNull);
             }
 
+            // Verify we still have our ServiceProvider middleware
+            if (OrchestrationMiddleware.FirstOrDefault(x => x.Type == typeof(ServiceProviderOrchestrationMiddleware)) is null)
+            {
+                throw new InvalidOperationException(Strings.ExpectedMiddlewareMissing(
+                    typeof(ServiceProviderOrchestrationMiddleware), nameof(OrchestrationMiddleware)));
+            }
+
+            if (ActivityMiddleware.FirstOrDefault(x => x.Type == typeof(ServiceProviderActivityMiddleware)) is null)
+            {
+                throw new InvalidOperationException(Strings.ExpectedMiddlewareMissing(
+                    typeof(ServiceProviderActivityMiddleware), nameof(ActivityMiddleware)));
+            }
+
             var worker = new TaskHubWorker(
                 OrchestrationService,
                 new WrapperObjectManager<TaskOrchestration>(

--- a/src/DurableTask.DependencyInjection/src/DefaultTaskHubWorkerBuilder.cs
+++ b/src/DurableTask.DependencyInjection/src/DefaultTaskHubWorkerBuilder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using DurableTask.Core;
 using DurableTask.Core.Middleware;
@@ -21,15 +22,6 @@ namespace DurableTask.DependencyInjection
     /// </summary>
     public class DefaultTaskHubWorkerBuilder : ITaskHubWorkerBuilder
     {
-        private readonly TaskHubCollection<TaskActivity> _activities
-            = new TaskHubCollection<TaskActivity>();
-
-        private readonly TaskHubCollection<TaskOrchestration> _orchestrations
-            = new TaskHubCollection<TaskOrchestration>();
-
-        private readonly List<Type> _activitiesMiddleware = new List<Type>();
-        private readonly List<Type> _orchestrationsMiddleware = new List<Type>();
-
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultTaskHubWorkerBuilder"/> class.
         /// </summary>
@@ -37,49 +29,33 @@ namespace DurableTask.DependencyInjection
         public DefaultTaskHubWorkerBuilder(IServiceCollection services)
         {
             Services = Check.NotNull(services, nameof(services));
-            Services.TryAddScoped<ServiceProviderOrchestrationMiddleware>();
             Services.TryAddScoped<ServiceProviderActivityMiddleware>();
+            Services.TryAddScoped<ServiceProviderOrchestrationMiddleware>();
         }
 
         /// <inheritdoc />
         public IServiceCollection Services { get; }
 
-        /// <summary>
-        /// Gets or sets the current orchestration service.
-        /// </summary>
+        /// <inheritdoc />
         public IOrchestrationService OrchestrationService { get; set; }
 
         /// <inheritdoc />
-        public ITaskHubWorkerBuilder AddActivity(TaskActivityDescriptor descriptor)
+        public IList<TaskMiddlewareDescriptor> ActivityMiddleware { get; } = new List<TaskMiddlewareDescriptor>
         {
-            Check.NotNull(descriptor, nameof(descriptor));
-            _activities.Add(descriptor);
-            return this;
-        }
+            new TaskMiddlewareDescriptor(typeof(ServiceProviderActivityMiddleware)),
+        };
 
         /// <inheritdoc />
-        public ITaskHubWorkerBuilder UseActivityMiddleware(TaskMiddlewareDescriptor descriptor)
+        public IList<TaskMiddlewareDescriptor> OrchestrationMiddleware { get; } = new List<TaskMiddlewareDescriptor>
         {
-            Check.NotNull(descriptor, nameof(descriptor));
-            _activitiesMiddleware.Add(descriptor.Type);
-            return this;
-        }
+            new TaskMiddlewareDescriptor(typeof(ServiceProviderOrchestrationMiddleware)),
+        };
 
-        /// <inheritdoc />
-        public ITaskHubWorkerBuilder AddOrchestration(TaskOrchestrationDescriptor descriptor)
-        {
-            Check.NotNull(descriptor, nameof(descriptor));
-            _orchestrations.Add(descriptor);
-            return this;
-        }
+        /// <inheritdoc/>
+        public IList<TaskActivityDescriptor> Activities { get; } = new List<TaskActivityDescriptor>();
 
-        /// <inheritdoc />
-        public ITaskHubWorkerBuilder UseOrchestrationMiddleware(TaskMiddlewareDescriptor descriptor)
-        {
-            Check.NotNull(descriptor, nameof(descriptor));
-            _orchestrationsMiddleware.Add(descriptor.Type);
-            return this;
-        }
+        /// <inheritdoc/>
+        public IList<TaskOrchestrationDescriptor> Orchestrations { get; } = new List<TaskOrchestrationDescriptor>();
 
         /// <summary>
         /// Builds and returns a <see cref="TaskHubWorker"/> using the configurations from this instance.
@@ -97,20 +73,20 @@ namespace DurableTask.DependencyInjection
 
             var worker = new TaskHubWorker(
                 OrchestrationService,
-                new WrapperObjectManager<TaskOrchestration>(_orchestrations, type => new WrapperOrchestration(type)),
-                new WrapperObjectManager<TaskActivity>(_activities, type => new WrapperActivity(type)));
+                new WrapperObjectManager<TaskOrchestration>(
+                    new TaskHubCollection<TaskOrchestration>(Orchestrations), type => new WrapperOrchestration(type)),
+                new WrapperObjectManager<TaskActivity>(
+                    new TaskHubCollection<TaskActivity>(Activities), type => new WrapperActivity(type)));
 
             // The first middleware added begins the service scope for all further middleware, the orchestration, and activities.
             worker.AddOrchestrationDispatcherMiddleware(BeginMiddlewareScope(serviceProvider));
-            worker.AddOrchestrationDispatcherMiddleware(WrapMiddleware(typeof(ServiceProviderOrchestrationMiddleware)));
-            foreach (Type middlewareType in _orchestrationsMiddleware)
+            foreach (Type middlewareType in OrchestrationMiddleware.Select(x => x.Type))
             {
                 worker.AddOrchestrationDispatcherMiddleware(WrapMiddleware(middlewareType));
             }
 
             worker.AddActivityDispatcherMiddleware(BeginMiddlewareScope(serviceProvider));
-            worker.AddActivityDispatcherMiddleware(WrapMiddleware(typeof(ServiceProviderActivityMiddleware)));
-            foreach (Type middlewareType in _activitiesMiddleware)
+            foreach (Type middlewareType in ActivityMiddleware.Select(x => x.Type))
             {
                 worker.AddActivityDispatcherMiddleware(WrapMiddleware(middlewareType));
             }

--- a/src/DurableTask.DependencyInjection/src/Extensions/TaskHubWorkerBuilderActivityExtensions.cs
+++ b/src/DurableTask.DependencyInjection/src/Extensions/TaskHubWorkerBuilderActivityExtensions.cs
@@ -14,6 +14,22 @@ namespace DurableTask.DependencyInjection
     public static class TaskHubWorkerBuilderActivityExtensions
     {
         /// <summary>
+        /// Adds the provided descriptor of an activity to the builder.
+        /// </summary>
+        /// <param name="builder">The builder to add to, not null.</param>
+        /// <param name="descriptor">The activity descriptor to add.</param>
+        /// <returns>This instance, for chaining calls.</returns>
+        public static ITaskHubWorkerBuilder AddActivity(
+            this ITaskHubWorkerBuilder builder, TaskActivityDescriptor descriptor)
+        {
+            Check.NotNull(builder, nameof(builder));
+            Check.NotNull(descriptor, nameof(descriptor));
+
+            builder.Activities.Add(descriptor);
+            return builder;
+        }
+
+        /// <summary>
         /// Adds the provided activity type to the builder.
         /// Includes <see cref="TaskAliasAttribute"/>.
         /// </summary>
@@ -36,7 +52,6 @@ namespace DurableTask.DependencyInjection
             Check.NotNull(builder, nameof(builder));
 
             builder.AddActivity(new TaskActivityDescriptor(type));
-
             if (includeAliases)
             {
                 foreach ((string name, string version) in type.GetTaskAliases())
@@ -136,6 +151,22 @@ namespace DurableTask.DependencyInjection
         public static ITaskHubWorkerBuilder AddActivitiesFromAssembly<T>(
             this ITaskHubWorkerBuilder builder, bool includePrivate = false)
             => AddActivitiesFromAssembly(builder, typeof(T).Assembly, includePrivate);
+
+        /// <summary>
+        /// Adds the provided middleware for task activities.
+        /// </summary>
+        /// <param name="builder">The builder to add to, not null.</param>
+        /// <param name="descriptor">The middleware descriptor to add.</param>
+        /// <returns>This instance, for chaining calls.</returns>
+        public static ITaskHubWorkerBuilder UseActivityMiddleware(
+            this ITaskHubWorkerBuilder builder, TaskMiddlewareDescriptor descriptor)
+        {
+            Check.NotNull(builder, nameof(builder));
+            Check.NotNull(descriptor, nameof(descriptor));
+
+            builder.ActivityMiddleware.Add(descriptor);
+            return builder;
+        }
 
         /// <summary>
         /// Adds the provided activity middleware to the builder.

--- a/src/DurableTask.DependencyInjection/src/Extensions/TaskHubWorkerBuilderOrchestrationExtensions.cs
+++ b/src/DurableTask.DependencyInjection/src/Extensions/TaskHubWorkerBuilderOrchestrationExtensions.cs
@@ -14,6 +14,22 @@ namespace DurableTask.DependencyInjection
     public static class TaskHubWorkerBuilderOrchestrationExtensions
     {
         /// <summary>
+        /// Adds the provided descriptor to the builder.
+        /// </summary>
+        /// <param name="builder">The builder to add to, not null.</param>
+        /// <param name="descriptor">The descriptor to add.</param>
+        /// <returns>This instance, for chaining calls.</returns>
+        public static ITaskHubWorkerBuilder AddOrchestration(
+            this ITaskHubWorkerBuilder builder, TaskOrchestrationDescriptor descriptor)
+        {
+            Check.NotNull(builder, nameof(builder));
+            Check.NotNull(descriptor, nameof(descriptor));
+
+            builder.Orchestrations.Add(descriptor);
+            return builder;
+        }
+
+        /// <summary>
         /// Adds the provided orchestration type to the builder.
         /// Includes <see cref="TaskAliasAttribute"/>.
         /// </summary>
@@ -135,6 +151,22 @@ namespace DurableTask.DependencyInjection
         public static ITaskHubWorkerBuilder AddOrchestrationsFromAssembly<T>(
             this ITaskHubWorkerBuilder builder, bool includePrivate = false)
             => AddOrchestrationsFromAssembly(builder, typeof(T).Assembly, includePrivate);
+
+        /// <summary>
+        /// Adds the provided middleware for task orchestrations.
+        /// </summary>
+        /// <param name="builder">The builder to add to, not null.</param>
+        /// <param name="descriptor">The middleware descriptor to add.</param>
+        /// <returns>This instance, for chaining calls.</returns>
+        public static ITaskHubWorkerBuilder UseOrchestrationMiddleware(
+            this ITaskHubWorkerBuilder builder, TaskMiddlewareDescriptor descriptor)
+        {
+            Check.NotNull(builder, nameof(builder));
+            Check.NotNull(descriptor, nameof(descriptor));
+
+            builder.OrchestrationMiddleware.Add(descriptor);
+            return builder;
+        }
 
         /// <summary>
         /// Adds the provided orchestration middleware to the builder.

--- a/src/DurableTask.DependencyInjection/src/ITaskHubWorkerBuilder.cs
+++ b/src/DurableTask.DependencyInjection/src/ITaskHubWorkerBuilder.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Jacob Viau. All rights reserved.
 // Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
 using DurableTask.Core;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -22,31 +24,23 @@ namespace DurableTask.DependencyInjection
         IOrchestrationService OrchestrationService { get; set; }
 
         /// <summary>
-        /// Adds the provided descriptor of an activity to the builder.
+        /// Gets the activity middleware.
         /// </summary>
-        /// <param name="descriptor">The activity descriptor to add.</param>
-        /// <returns>This instance, for chaining calls.</returns>
-        ITaskHubWorkerBuilder AddActivity(TaskActivityDescriptor descriptor);
+        IList<TaskMiddlewareDescriptor> ActivityMiddleware { get; }
 
         /// <summary>
-        /// Adds the provided middleware for task activities.
+        /// Gets the orchestration middleware.
         /// </summary>
-        /// <param name="descriptor">The middleware descriptor to add.</param>
-        /// <returns>This instance, for chaining calls.</returns>
-        ITaskHubWorkerBuilder UseActivityMiddleware(TaskMiddlewareDescriptor descriptor);
+        IList<TaskMiddlewareDescriptor> OrchestrationMiddleware { get; }
 
         /// <summary>
-        /// Adds the provided descriptor to the builder.
+        /// Gets the activities.
         /// </summary>
-        /// <param name="descriptor">The descriptor to add.</param>
-        /// <returns>This instance, for chaining calls.</returns>
-        ITaskHubWorkerBuilder AddOrchestration(TaskOrchestrationDescriptor descriptor);
+        IList<TaskActivityDescriptor> Activities { get; }
 
         /// <summary>
-        /// Adds the provided middleware for task orchestrations.
+        /// Gets the orchestrations.
         /// </summary>
-        /// <param name="descriptor">The middleware descriptor to add.</param>
-        /// <returns>This instance, for chaining calls.</returns>
-        ITaskHubWorkerBuilder UseOrchestrationMiddleware(TaskMiddlewareDescriptor descriptor);
+        IList<TaskOrchestrationDescriptor> Orchestrations { get; }
     }
 }

--- a/src/DurableTask.DependencyInjection/src/Properties/Strings.Designer.cs
+++ b/src/DurableTask.DependencyInjection/src/Properties/Strings.Designer.cs
@@ -17,6 +17,15 @@ namespace DurableTask.DependencyInjection.Properties
             => GetString("AddToObjectManagerNotSupported");
 
         /// <summary>
+        ///     Expected middleware of type '{type}' to be present in '{list}'.
+        /// </summary>
+        public static string ExpectedMiddlewareMissing(object type, object list)
+            => string.Format(
+                GetString("ExpectedMiddlewareMissing", nameof(type), nameof(list)),
+                type, list,
+                CultureInfo.CurrentUICulture);
+
+        /// <summary>
         ///     InnerActivity is null.
         /// </summary>
         public static string InnerActivityNull

--- a/src/DurableTask.DependencyInjection/src/Properties/Strings.resx
+++ b/src/DurableTask.DependencyInjection/src/Properties/Strings.resx
@@ -120,6 +120,9 @@
   <data name="AddToObjectManagerNotSupported" xml:space="preserve">
     <value>Add is not supported. Use the &lt;c&gt;ITaskHubWorkerBuilder&lt;/c&gt; instead.</value>
   </data>
+  <data name="ExpectedMiddlewareMissing" xml:space="preserve">
+    <value>Expected middleware of type '{type}' to be present in '{list}'.</value>
+  </data>
   <data name="InnerActivityNull" xml:space="preserve">
     <value>InnerActivity is null.</value>
   </data>

--- a/src/DurableTask.DependencyInjection/src/TaskHubCollection`1.cs
+++ b/src/DurableTask.DependencyInjection/src/TaskHubCollection`1.cs
@@ -14,11 +14,19 @@ namespace DurableTask.DependencyInjection
     /// <typeparam name="TDescribed">The described type in this collection.</typeparam>
     internal class TaskHubCollection<TDescribed> : ITaskObjectCollection<TDescribed>
     {
-        private readonly HashSet<NamedTypeDescriptor<TDescribed>> _descriptors
-            = new HashSet<NamedTypeDescriptor<TDescribed>>();
+        private readonly HashSet<NamedTypeDescriptor<TDescribed>> _descriptors;
 
         private readonly ConcurrentDictionary<TaskVersion, Type> _typeMap
             = new ConcurrentDictionary<TaskVersion, Type>();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TaskHubCollection{TDescribed}"/> class.
+        /// </summary>
+        /// <param name="descriptors">The list of current descriptors.</param>
+        public TaskHubCollection(IEnumerable<NamedTypeDescriptor<TDescribed>> descriptors)
+        {
+            _descriptors = new HashSet<NamedTypeDescriptor<TDescribed>>(descriptors);
+        }
 
         /// <inheritdoc />
         public int Count => _descriptors.Count;
@@ -33,14 +41,6 @@ namespace DurableTask.DependencyInjection
 
         /// <inheritdoc />
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
-        /// <summary>
-        /// Adds the descriptor to this collection.
-        /// </summary>
-        /// <param name="descriptor">The descriptor to add.</param>
-        /// <returns>True if descriptor added, false otherwise.</returns>
-        public bool Add(NamedTypeDescriptor<TDescribed> descriptor)
-            => _descriptors.Add(descriptor);
 
         private Type GetTaskType(string name, string version)
         {

--- a/src/DurableTask.DependencyInjection/test/DefaultTaskHubWorkerBuilderTests.cs
+++ b/src/DurableTask.DependencyInjection/test/DefaultTaskHubWorkerBuilderTests.cs
@@ -17,20 +17,19 @@ namespace DurableTask.DependencyInjection.Tests
             => RunTestException<ArgumentNullException>(_ => new DefaultTaskHubWorkerBuilder(null));
 
         [Fact]
-        public void AddActivityNull()
-            => RunTestException<ArgumentNullException>(b => b.AddActivity(null));
-
-        [Fact]
-        public void AddActivityMiddlewareNull()
-            => RunTestException<ArgumentNullException>(b => b.UseActivityMiddleware(null));
-
-        [Fact]
-        public void AddOrchestrationNull()
-            => RunTestException<ArgumentNullException>(b => b.AddOrchestration(null));
-
-        [Fact]
-        public void AddOrchestrationMiddlewareNull()
-            => RunTestException<ArgumentNullException>(b => b.UseOrchestrationMiddleware(null));
+        public void CtorPropertiesSet()
+        {
+            RunTest(
+                null,
+                b => { },
+                (b, s) =>
+                {
+                    b.Activities.Should().NotBeNull();
+                    b.ActivityMiddleware.Should().NotBeNull();
+                    b.Orchestrations.Should().NotBeNull();
+                    b.OrchestrationMiddleware.Should().NotBeNull();
+                });
+        }
 
         [Fact]
         public void BuildNullServiceProvider()

--- a/src/DurableTask.DependencyInjection/test/TaskHubCollectionTests.cs
+++ b/src/DurableTask.DependencyInjection/test/TaskHubCollectionTests.cs
@@ -11,47 +11,11 @@ namespace DurableTask.DependencyInjection.Tests
     public class TaskHubCollectionTests
     {
         [Fact]
-        public void Add_Succeeds()
-        {
-            // arrange
-            var activity = new TaskActivityDescriptor(typeof(TestActivity));
-            var descriptors = new TaskHubCollection<TaskActivity>();
-
-            // act
-            bool result = descriptors.Add(activity);
-
-            // assert
-            result.Should().BeTrue();
-            descriptors.Should().HaveCount(1);
-            descriptors.Single().Should().Be(activity);
-        }
-
-        [Fact]
-        public void Add_Duplicate()
-        {
-            // arrange
-            var activity = new TaskActivityDescriptor(typeof(TestActivity));
-            var descriptors = new TaskHubCollection<TaskActivity>();
-
-            // act
-            descriptors.Add(activity);
-            bool result = descriptors.Add(activity);
-
-            // assert
-            result.Should().BeFalse();
-            descriptors.Should().HaveCount(1);
-            descriptors.Single().Should().Be(activity);
-        }
-
-        [Fact]
         public void EnumeratorOfT_ContainsAll()
         {
             // arrange
             var activity = new TaskActivityDescriptor(typeof(TestActivity));
-            var descriptors = new TaskHubCollection<TaskActivity>()
-            {
-                activity,
-            };
+            var descriptors = new TaskHubCollection<TaskActivity>(new[] { activity });
 
             // act
             IEnumerator<NamedTypeDescriptor<TaskActivity>> enumerator = descriptors.GetEnumerator();
@@ -69,10 +33,7 @@ namespace DurableTask.DependencyInjection.Tests
         {
             // arrange
             var activity = new TaskActivityDescriptor(typeof(TestActivity));
-            var descriptors = new TaskHubCollection<TaskActivity>()
-            {
-                activity,
-            };
+            var descriptors = new TaskHubCollection<TaskActivity>(new[] { activity });
 
             // act
             IEnumerator enumerator = ((IEnumerable)descriptors).GetEnumerator();
@@ -89,10 +50,7 @@ namespace DurableTask.DependencyInjection.Tests
         {
             // arrange
             var activity = new TaskActivityDescriptor(typeof(TestActivity));
-            var descriptors = new TaskHubCollection<TaskActivity>()
-            {
-                activity,
-            };
+            var descriptors = new TaskHubCollection<TaskActivity>(new[] { activity });
 
             // act
             Type actual = descriptors["DNE", string.Empty];
@@ -106,10 +64,7 @@ namespace DurableTask.DependencyInjection.Tests
         {
             // arrange
             var activity = new TaskActivityDescriptor(typeof(TestActivity));
-            var descriptors = new TaskHubCollection<TaskActivity>()
-            {
-                activity,
-            };
+            var descriptors = new TaskHubCollection<TaskActivity>(new[] { activity });
 
             // act
             Type actual = descriptors[activity.Name, activity.Version];
@@ -125,11 +80,7 @@ namespace DurableTask.DependencyInjection.Tests
             // arrange
             var activity = new TaskActivityDescriptor(typeof(TestActivity));
             var activity2 = new TaskActivityDescriptor(typeof(TestActivity2));
-            var descriptors = new TaskHubCollection<TaskActivity>()
-            {
-                activity,
-                activity2,
-            };
+            var descriptors = new TaskHubCollection<TaskActivity>(new[] { activity, activity2 });
 
             // act
             Type actual = descriptors[activity2.Name, activity2.Version];
@@ -144,10 +95,7 @@ namespace DurableTask.DependencyInjection.Tests
         {
             // arrange
             var activity = new TaskActivityDescriptor(typeof(TestActivity));
-            var descriptors = new TaskHubCollection<TaskActivity>()
-            {
-                activity,
-            };
+            var descriptors = new TaskHubCollection<TaskActivity>(new[] { activity });
 
             // act
             Type actual = descriptors[activity.Name, activity.Version];
@@ -163,7 +111,7 @@ namespace DurableTask.DependencyInjection.Tests
         public void Count_Zero()
         {
             // arrange
-            var descriptors = new TaskHubCollection<TaskActivity>();
+            var descriptors = new TaskHubCollection<TaskActivity>(Enumerable.Empty<TaskActivityDescriptor>());
 
             // act
             int count = descriptors.Count;
@@ -178,11 +126,7 @@ namespace DurableTask.DependencyInjection.Tests
             // arrange
             var activity = new TaskActivityDescriptor(typeof(TestActivity));
             var activity2 = new TaskActivityDescriptor(typeof(TestActivity2));
-            var descriptors = new TaskHubCollection<TaskActivity>()
-            {
-                activity,
-                activity2,
-            };
+            var descriptors = new TaskHubCollection<TaskActivity>(new[] { activity, activity2 });
 
             // act
             int count = descriptors.Count;

--- a/src/DurableTask.Hosting/src/Options/TaskHubOptions.cs
+++ b/src/DurableTask.Hosting/src/Options/TaskHubOptions.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Jacob Viau. All rights reserved.
 // Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
 using DurableTask.Core;
+using DurableTask.DependencyInjection;
 
 namespace DurableTask.Hosting.Options
 {

--- a/src/DurableTask.Hosting/src/Options/TaskHubOptions.cs
+++ b/src/DurableTask.Hosting/src/Options/TaskHubOptions.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) Jacob Viau. All rights reserved.
 // Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using DurableTask.Core;
-using DurableTask.DependencyInjection;
 
 namespace DurableTask.Hosting.Options
 {


### PR DESCRIPTION
- Changes ITaskHubWorkerBuilder to track inserted items via public Lists
- This can be used to remove or insert items at a specific position

Closes #2 - users can now insert their middleware before the built-in middleware.