### PR TITLE
Update to DTFx 2.4.0, add ILoggerFactory to TaskHub

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -2,9 +2,9 @@
 
   <!-- Azure -->
   <ItemGroup>
-    <PackageReference Update="Microsoft.Azure.DurableTask.Core" Version="2.2.4" />
-    <PackageReference Update="Microsoft.Azure.DurableTask.Emulator" Version="2.2.4" />
-    <PackageReference Update="Microsoft.Azure.DurableTask.ServiceBus" Version="2.1.3" />
+    <PackageReference Update="Microsoft.Azure.DurableTask.Core" Version="2.4.0" />
+    <PackageReference Update="Microsoft.Azure.DurableTask.Emulator" Version="2.2.5" />
+    <PackageReference Update="Microsoft.Azure.DurableTask.ServiceBus" Version="2.4.0" />
   </ItemGroup>
 
   <!-- Microsoft Extensions -->

--- a/src/DurableTask.DependencyInjection/src/DefaultTaskHubWorkerBuilder.cs
+++ b/src/DurableTask.DependencyInjection/src/DefaultTaskHubWorkerBuilder.cs
@@ -14,6 +14,7 @@ using DurableTask.DependencyInjection.Orchestrations;
 using DurableTask.DependencyInjection.Properties;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 
 namespace DurableTask.DependencyInjection
 {
@@ -84,12 +85,14 @@ namespace DurableTask.DependencyInjection
                     typeof(ServiceProviderActivityMiddleware), nameof(ActivityMiddleware)));
             }
 
+            ILoggerFactory loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
             var worker = new TaskHubWorker(
                 OrchestrationService,
                 new WrapperObjectManager<TaskOrchestration>(
                     new TaskHubCollection<TaskOrchestration>(Orchestrations), type => new WrapperOrchestration(type)),
                 new WrapperObjectManager<TaskActivity>(
-                    new TaskHubCollection<TaskActivity>(Activities), type => new WrapperActivity(type)));
+                    new TaskHubCollection<TaskActivity>(Activities), type => new WrapperActivity(type)),
+                loggerFactory);
 
             // The first middleware added begins the service scope for all further middleware, the orchestration, and activities.
             worker.AddOrchestrationDispatcherMiddleware(BeginMiddlewareScope(serviceProvider));

--- a/src/DurableTask.Hosting/src/Extensions/TaskHubHostBuilderExtensions.cs
+++ b/src/DurableTask.Hosting/src/Extensions/TaskHubHostBuilderExtensions.cs
@@ -80,6 +80,9 @@ namespace DurableTask.Hosting
 
             builder.ConfigureServices((context, services) =>
             {
+                services.AddOptions();
+                services.AddLogging();
+
                 services
                     .AddOptions<TaskHubOptions>()
                     .Bind(context.Configuration.GetSection("TaskHub"))


### PR DESCRIPTION
DTFx added support for `ILoggerFactory` in 2.4.0, this PR upgrades to that version and passes in the `ILoggerFactory` from the `IServiceProvider` for both client and worker.