### PR TITLE
Add support for open generic tasks

### DIFF
--- a/samples/DurableTask.Samples/Generics/GenericActivity`1.cs
+++ b/samples/DurableTask.Samples/Generics/GenericActivity`1.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Jacob Viau. All rights reserved.
+// Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
+
+using DurableTask.Core;
+
+namespace DurableTask.Samples.Generics
+{
+    /// <summary>
+    /// An example of an open generic activity.
+    /// </summary>
+    /// <typeparam name="T">The open generic type.</typeparam>
+    public class GenericActivity<T> : TaskActivity<T, string>
+    {
+        /// <inheritdoc />
+        protected override string Execute(TaskContext context, T input)
+        {
+            return $"My generic param is {typeof(T)} with value '{input}'";
+        }
+    }
+}

--- a/samples/DurableTask.Samples/Generics/GenericOrchestrationRunner.cs
+++ b/samples/DurableTask.Samples/Generics/GenericOrchestrationRunner.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Jacob Viau. All rights reserved.
+// Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+using DurableTask.Core;
+
+namespace DurableTask.Samples.Generics
+{
+    /// <summary>
+    /// Runner for generic tasks example.
+    /// </summary>
+    public class GenericOrchestrationRunner : TaskOrchestration<string, string>
+    {
+        /// <inheritdoc />
+        public override async Task<string> RunTask(OrchestrationContext context, string input)
+        {
+            string result = await context.ScheduleTask<string>(typeof(GenericActivity<int>), 10);
+            await PrintAsync(context, result);
+
+            result = await context.ScheduleTask<string>(typeof(GenericActivity<string>), "example");
+            await PrintAsync(context, result);
+
+            result = await context.ScheduleTask<string>(typeof(GenericActivity<MyClass>), new MyClass());
+            await PrintAsync(context, result);
+
+            return null;
+        }
+
+        private Task<string> PrintAsync(OrchestrationContext context, string input)
+        {
+            return context.ScheduleTask<string>(typeof(PrintTask), input);
+        }
+
+        private class MyClass
+        {
+            public override string ToString() => "Example private class";
+        }
+    }
+}

--- a/samples/DurableTask.Samples/PrintTask.cs
+++ b/samples/DurableTask.Samples/PrintTask.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Jacob Viau. All rights reserved.
+// Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
+
+using System;
+using DurableTask.Core;
+
+namespace DurableTask.Samples
+{
+    /// <summary>
+    /// An activity to print to the console.
+    /// </summary>
+    public class PrintTask : TaskActivity<string, string>
+    {
+        private readonly IConsole _console;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PrintTask"/> class.
+        /// </summary>
+        /// <param name="console">The console to print to.</param>
+        public PrintTask(IConsole console)
+        {
+            _console = console ?? throw new ArgumentNullException(nameof(console));
+        }
+
+        /// <inheritdoc />
+        protected override string Execute(TaskContext context, string input)
+        {
+            _console.WriteLine(input);
+            return null;
+        }
+    }
+}

--- a/samples/DurableTask.Samples/Program.cs
+++ b/samples/DurableTask.Samples/Program.cs
@@ -44,7 +44,6 @@ namespace DurableTask.Samples
                 {
                     // IOrchestrationService orchestrationService = UseServiceBus(context.Configuration);
                     IOrchestrationService orchestrationService = UseLocalEmulator();
-
                     builder.WithOrchestrationService(orchestrationService);
 
                     builder.AddClient();
@@ -59,11 +58,13 @@ namespace DurableTask.Samples
                         .AddOrchestration<GreetingsOrchestration>()
                         .AddOrchestration<GenericOrchestrationRunner>();
 
-                    builder
-                        .AddActivity<PrintTask>()
-                        .AddActivity<GetUserTask>()
-                        .AddActivity<SendGreetingTask>()
-                        .AddActivity(typeof(GenericActivity<>));
+                    //builder
+                    //    .AddActivity<PrintTask>()
+                    //    .AddActivity<GetUserTask>()
+                    //    .AddActivity<SendGreetingTask>()
+                    //    .AddActivity(typeof(GenericActivity<>));
+
+                    builder.AddActivitiesFromAssembly<Program>();
                 })
                 .UseConsoleLifetime()
                 .Build();

--- a/samples/DurableTask.Samples/Program.cs
+++ b/samples/DurableTask.Samples/Program.cs
@@ -12,8 +12,8 @@ using DurableTask.Core;
 using DurableTask.DependencyInjection;
 using DurableTask.Emulator;
 using DurableTask.Hosting;
+using DurableTask.Samples.Generics;
 using DurableTask.Samples.Greetings;
-using Dynamitey.DynamicObjects;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -55,10 +55,15 @@ namespace DurableTask.Samples
                     builder.UseActivityMiddleware<ActivityInstanceExMiddleware>();
                     builder.UseActivityMiddleware<SampleMiddleware>();
 
-                    builder.AddOrchestration<GreetingsOrchestration>();
                     builder
+                        .AddOrchestration<GreetingsOrchestration>()
+                        .AddOrchestration<GenericOrchestrationRunner>();
+
+                    builder
+                        .AddActivity<PrintTask>()
                         .AddActivity<GetUserTask>()
-                        .AddActivity<SendGreetingTask>();
+                        .AddActivity<SendGreetingTask>()
+                        .AddActivity(typeof(GenericActivity<>));
                 })
                 .UseConsoleLifetime()
                 .Build();
@@ -178,14 +183,14 @@ namespace DurableTask.Samples
             protected override async Task ExecuteAsync(CancellationToken stoppingToken)
             {
                 OrchestrationInstance instance = await _client.CreateOrchestrationInstanceAsync(
-                        NameVersionHelper.GetDefaultName(typeof(GreetingsOrchestration)),
-                        NameVersionHelper.GetDefaultVersion(typeof(GreetingsOrchestration)),
-                        _instanceId,
-                        null,
-                        new Dictionary<string, string>()
-                        {
-                            ["CorrelationId"] = Guid.NewGuid().ToString(),
-                        });
+                    NameVersionHelper.GetDefaultName(typeof(GenericOrchestrationRunner)),
+                    NameVersionHelper.GetDefaultVersion(typeof(GenericOrchestrationRunner)),
+                    _instanceId,
+                    null,
+                    new Dictionary<string, string>()
+                    {
+                        ["CorrelationId"] = Guid.NewGuid().ToString(),
+                    });
 
                 OrchestrationState result = await _client.WaitForOrchestrationAsync(
                     instance, TimeSpan.FromSeconds(60));

--- a/src/DurableTask.DependencyInjection/src/Activities/ActivityObjectCreator.cs
+++ b/src/DurableTask.DependencyInjection/src/Activities/ActivityObjectCreator.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Jacob Viau. All rights reserved.
 // Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
 
+using System;
 using DurableTask.Core;
 
 namespace DurableTask.DependencyInjection.Activities
@@ -8,7 +9,7 @@ namespace DurableTask.DependencyInjection.Activities
     /// <summary>
     /// Object creator driven by the provided descriptor.
     /// </summary>
-    internal class ActivityObjectCreator : ObjectCreator<TaskActivity>
+    internal class ActivityObjectCreator : GenericObjectCreator<TaskActivity>
     {
         private readonly TaskActivityDescriptor _descriptor;
 
@@ -27,5 +28,20 @@ namespace DurableTask.DependencyInjection.Activities
 
         /// <inheritdoc/>
         public override TaskActivity Create() => new WrapperActivity(_descriptor);
+
+        /// <inheritdoc/>
+        public override TaskActivity Create(string closedName)
+        {
+            Check.NotNullOrEmpty(closedName, nameof(closedName));
+            if (_descriptor.Type?.IsGenericTypeDefinition != true)
+            {
+                throw new InvalidOperationException("This is not a generic type definition descriptor.");
+            }
+
+            Type closedType = _descriptor.Type.Assembly.GetType(closedName, throwOnError: true);
+            Check.Argument(closedType.IsConstructedGenericType, nameof(closedType), "Type must be closed");
+
+            return new WrapperActivity(new TaskActivityDescriptor(closedType));
+        }
     }
 }

--- a/src/DurableTask.DependencyInjection/src/Activities/ActivityObjectCreator.cs
+++ b/src/DurableTask.DependencyInjection/src/Activities/ActivityObjectCreator.cs
@@ -27,7 +27,15 @@ namespace DurableTask.DependencyInjection.Activities
         }
 
         /// <inheritdoc/>
-        public override TaskActivity Create() => new WrapperActivity(_descriptor);
+        public override TaskActivity Create()
+        {
+            if (_descriptor.Type?.IsGenericTypeDefinition == true)
+            {
+                throw new InvalidOperationException("Cannot create activity for generic definition");
+            }
+
+            return new WrapperActivity(_descriptor);
+        }
 
         /// <inheritdoc/>
         public override TaskActivity Create(string closedName)

--- a/src/DurableTask.DependencyInjection/src/Activities/TaskActivityDescriptor.cs
+++ b/src/DurableTask.DependencyInjection/src/Activities/TaskActivityDescriptor.cs
@@ -65,5 +65,16 @@ namespace DurableTask.DependencyInjection
         /// Gets the <see cref="MethodInfo"/> to fetch and execute.
         /// </summary>
         public MethodInfo Method { get; }
+
+        /// <summary>
+        /// Creates a new descriptor for <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The activity type to describe.</typeparam>
+        /// <param name="name">The name of the activity. Optional.</param>
+        /// <param name="version">The version of the activity. Optional.</param>
+        /// <returns>A new descriptor.</returns>
+        public static TaskActivityDescriptor Create<T>(string name = null, string version = null)
+            where T : TaskActivity
+            => new TaskActivityDescriptor(typeof(T), name, version);
     }
 }

--- a/src/DurableTask.DependencyInjection/src/Activities/TaskActivityDescriptor.cs
+++ b/src/DurableTask.DependencyInjection/src/Activities/TaskActivityDescriptor.cs
@@ -25,7 +25,7 @@ namespace DurableTask.DependencyInjection
             Check.ConcreteType<TaskActivity>(type, nameof(type));
 
             Type = type;
-            Name = name ?? NameVersionHelper.GetDefaultName(type);
+            Name = name ?? GenericNameHelper.GetDefaultName(type);
             Version = version ?? NameVersionHelper.GetDefaultVersion(type);
         }
 
@@ -40,6 +40,8 @@ namespace DurableTask.DependencyInjection
         public TaskActivityDescriptor(MethodInfo method, string name = null, string version = null)
         {
             Method = Check.NotNull(method, nameof(method));
+            Check.NotNull(method.DeclaringType, nameof(method) + nameof(method.DeclaringType));
+
             Name = name ?? NameVersionHelper.GetDefaultName(method);
             Version = version ?? NameVersionHelper.GetDefaultVersion(method);
         }

--- a/src/DurableTask.DependencyInjection/src/Activities/WrapperActivity.cs
+++ b/src/DurableTask.DependencyInjection/src/Activities/WrapperActivity.cs
@@ -63,7 +63,7 @@ namespace DurableTask.DependencyInjection.Activities
                 if (serviceProvider.GetService(Descriptor.Type) is TaskActivity activity)
                 {
                     InnerActivity = activity;
-                    s_factories[Descriptor] = sp => (TaskActivity)sp.GetRequiredService(Descriptor.Type);
+                    s_factories.TryAdd(Descriptor, sp => (TaskActivity)sp.GetRequiredService(Descriptor.Type));
                     return; // already created it this time, so return now.
                 }
                 else

--- a/src/DurableTask.DependencyInjection/src/DefaultTaskHubWorkerBuilder.cs
+++ b/src/DurableTask.DependencyInjection/src/DefaultTaskHubWorkerBuilder.cs
@@ -83,7 +83,12 @@ namespace DurableTask.DependencyInjection
             }
 
             ILoggerFactory loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
-            var worker = new TaskHubWorker(OrchestrationService, loggerFactory);
+            var worker = new TaskHubWorker(
+                OrchestrationService,
+                new GenericObjectManager<TaskOrchestration>(),
+                new GenericObjectManager<TaskActivity>(),
+                loggerFactory);
+
             worker.AddTaskOrchestrations(Orchestrations.Select(x => new OrchestrationObjectCreator(x)).ToArray());
             worker.AddTaskActivities(Activities.Select(x => new ActivityObjectCreator(x)).ToArray());
 

--- a/src/DurableTask.DependencyInjection/src/GenericNameHelper.cs
+++ b/src/DurableTask.DependencyInjection/src/GenericNameHelper.cs
@@ -19,6 +19,8 @@ namespace DurableTask.DependencyInjection
         /// <returns>True if name represented a generic, false otherwise.</returns>
         public static bool TryGetGenericName(string name, out string genericName)
         {
+            Check.NotNull(name, nameof(name));
+
             // For a name of "Namespace.MyType`N[SomeSubtype]" we want "Namespace.MyType`N"
             int genericSplitter = name.IndexOf('[');
             if (genericSplitter < 0)

--- a/src/DurableTask.DependencyInjection/src/GenericNameHelper.cs
+++ b/src/DurableTask.DependencyInjection/src/GenericNameHelper.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Jacob Viau. All rights reserved.
+// Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
+
+using System;
+using DurableTask.Core;
+
+namespace DurableTask.DependencyInjection
+{
+    /// <summary>
+    /// Helpers for processing open and closed generic names.
+    /// </summary>
+    internal static class GenericNameHelper
+    {
+        /// <summary>
+        /// For a name of "Namespace.MyType`N[SomeSubtype]" gets "Namespace.MyType`N".
+        /// </summary>
+        /// <param name="name">The type name to process.</param>
+        /// <param name="genericName">The found generic name.</param>
+        /// <returns>True if name represented a generic, false otherwise.</returns>
+        public static bool TryGetGenericName(string name, out string genericName)
+        {
+            // For a name of "Namespace.MyType`N[SomeSubtype]" we want "Namespace.MyType`N"
+            int genericSplitter = name.IndexOf('[');
+            if (genericSplitter < 0)
+            {
+                genericName = null;
+                return false;
+            }
+
+            genericName = name.Substring(0, genericSplitter);
+            return true;
+        }
+
+        /// <summary>
+        /// Gets the default name for a type.
+        /// </summary>
+        /// <param name="type">The type to get a name for.</param>
+        /// <returns>The default name for this type.</returns>
+        public static string GetDefaultName(Type type)
+        {
+            Check.NotNull(type, nameof(type));
+            return type.FullName;
+        }
+    }
+}

--- a/src/DurableTask.DependencyInjection/src/GenericObjectCreator`1.cs
+++ b/src/DurableTask.DependencyInjection/src/GenericObjectCreator`1.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Jacob Viau. All rights reserved.
+// Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
+
+using DurableTask.Core;
+
+namespace DurableTask.DependencyInjection
+{
+    /// <summary>
+    /// A descriptor object creator.
+    /// </summary>
+    /// <typeparam name="T">The type of object to create.</typeparam>
+    internal abstract class GenericObjectCreator<T> : ObjectCreator<T>
+    {
+        /// <summary>
+        /// Creates an instance of <typeparamref name="T"/>, given the closed type name for T.
+        /// </summary>
+        /// <param name="closedName">The closed type name of T.</param>
+        /// <returns>An instance of T.</returns>
+        /// <remarks>
+        /// This is called when this creator represents an open-generic version of T, with the provided type
+        /// <paramref name="closedName"/> being the closed form to create.
+        /// </remarks>
+        public abstract T Create(string closedName);
+    }
+}

--- a/src/DurableTask.DependencyInjection/src/GenericObjectManager`1.cs
+++ b/src/DurableTask.DependencyInjection/src/GenericObjectManager`1.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Jacob Viau. All rights reserved.
+// Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Concurrent;
+using DurableTask.Core;
+
+namespace DurableTask.DependencyInjection
+{
+    /// <summary>
+    /// An object manager that enables open-generic creators.
+    /// </summary>
+    /// <typeparam name="T">The type managed by this.</typeparam>
+    internal sealed class GenericObjectManager<T> : INameVersionObjectManager<T>
+    {
+        private readonly ConcurrentDictionary<string, ObjectCreator<T>> _creators
+            = new ConcurrentDictionary<string, ObjectCreator<T>>();
+
+        /// <inheritdoc/>
+        public void Add(ObjectCreator<T> creator)
+        {
+            string key = GetKey(creator.Name, creator.Version);
+            if (!_creators.TryAdd(key, creator))
+            {
+                throw new InvalidOperationException($"Key '{key}' already exists.");
+            }
+        }
+
+        /// <inheritdoc/>
+        public T GetObject(string name, string version)
+        {
+            (ObjectCreator<T> creator, bool isGenericType) = GetCreator(name, version);
+
+            if (creator is null)
+            {
+                return default;
+            }
+
+            if (isGenericType && creator is GenericObjectCreator<T> genericCreator)
+            {
+                return genericCreator.Create(name);
+            }
+
+            return creator.Create();
+        }
+
+        private static string GetKey(string name, string version) => $"{name}|{version}";
+
+        private (ObjectCreator<T> Creator, bool IsGenericType) GetCreator(string name, string version)
+        {
+            // First check if the name is registered directly.
+            if (_creators.TryGetValue(GetKey(name, version), out ObjectCreator<T> creator))
+            {
+                return (creator, false);
+            }
+
+            // Then check if this represents a generic type, and find the generic definition name.
+            if (GenericNameHelper.TryGetGenericName(name, out string genericName) &&
+                _creators.TryGetValue(GetKey(genericName, version), out creator))
+            {
+                return (creator, true);
+            }
+
+            return (default, false);
+        }
+    }
+}

--- a/src/DurableTask.DependencyInjection/src/Orchestrations/OrchestrationObjectCreator.cs
+++ b/src/DurableTask.DependencyInjection/src/Orchestrations/OrchestrationObjectCreator.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Jacob Viau. All rights reserved.
 // Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
 
+using System;
 using DurableTask.Core;
 
 namespace DurableTask.DependencyInjection.Orchestrations
@@ -8,7 +9,7 @@ namespace DurableTask.DependencyInjection.Orchestrations
     /// <summary>
     /// Object creator satisfied from the service provider.
     /// </summary>
-    internal class OrchestrationObjectCreator : ObjectCreator<TaskOrchestration>
+    internal class OrchestrationObjectCreator : GenericObjectCreator<TaskOrchestration>
     {
         private readonly TaskOrchestrationDescriptor _descriptor;
 
@@ -27,5 +28,20 @@ namespace DurableTask.DependencyInjection.Orchestrations
 
         /// <inheritdoc/>
         public override TaskOrchestration Create() => new WrapperOrchestration(_descriptor);
+
+        /// <inheritdoc/>
+        public override TaskOrchestration Create(string closedName)
+        {
+            Check.NotNull(closedName, nameof(closedName));
+            if (_descriptor.Type?.IsGenericTypeDefinition != true)
+            {
+                throw new InvalidOperationException("This is not a generic type definition creator.");
+            }
+
+            Type closedType = _descriptor.Type.Assembly.GetType(closedName, throwOnError: true);
+            Check.Argument(closedType.IsConstructedGenericType, nameof(closedType), "Type must be closed");
+
+            return new WrapperOrchestration(new TaskOrchestrationDescriptor(closedType));
+        }
     }
 }

--- a/src/DurableTask.DependencyInjection/src/Orchestrations/OrchestrationObjectCreator.cs
+++ b/src/DurableTask.DependencyInjection/src/Orchestrations/OrchestrationObjectCreator.cs
@@ -27,7 +27,15 @@ namespace DurableTask.DependencyInjection.Orchestrations
         }
 
         /// <inheritdoc/>
-        public override TaskOrchestration Create() => new WrapperOrchestration(_descriptor);
+        public override TaskOrchestration Create()
+        {
+            if (_descriptor.Type?.IsGenericTypeDefinition == true)
+            {
+                throw new InvalidOperationException("Cannot create activity for generic definition");
+            }
+
+            return new WrapperOrchestration(_descriptor);
+        }
 
         /// <inheritdoc/>
         public override TaskOrchestration Create(string closedName)

--- a/src/DurableTask.DependencyInjection/src/Orchestrations/TaskOrchestrationDescriptor.cs
+++ b/src/DurableTask.DependencyInjection/src/Orchestrations/TaskOrchestrationDescriptor.cs
@@ -41,5 +41,16 @@ namespace DurableTask.DependencyInjection
         /// Gets the type held by this descriptor.
         /// </summary>
         public Type Type { get; }
+
+        /// <summary>
+        /// Creates a new descriptor for <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The orchestration type to describe.</typeparam>
+        /// <param name="name">The name of the orchestration. Optional.</param>
+        /// <param name="version">The version of the orchestration. Optional.</param>
+        /// <returns>A new descriptor.</returns>
+        public static TaskOrchestrationDescriptor Create<T>(string name = null, string version = null)
+            where T : TaskOrchestration
+            => new TaskOrchestrationDescriptor(typeof(T), name, version);
     }
 }

--- a/src/DurableTask.DependencyInjection/src/Orchestrations/TaskOrchestrationDescriptor.cs
+++ b/src/DurableTask.DependencyInjection/src/Orchestrations/TaskOrchestrationDescriptor.cs
@@ -23,7 +23,7 @@ namespace DurableTask.DependencyInjection
             Check.ConcreteType<TaskOrchestration>(type, nameof(type));
 
             Type = type;
-            Name = name ?? NameVersionHelper.GetDefaultName(type);
+            Name = name ?? GenericNameHelper.GetDefaultName(type);
             Version = version ?? NameVersionHelper.GetDefaultVersion(type);
         }
 

--- a/src/DurableTask.DependencyInjection/src/Orchestrations/WrapperOrchestration.cs
+++ b/src/DurableTask.DependencyInjection/src/Orchestrations/WrapperOrchestration.cs
@@ -52,7 +52,7 @@ namespace DurableTask.DependencyInjection.Orchestrations
                 if (serviceProvider.GetService(Descriptor.Type) is TaskOrchestration orchestration)
                 {
                     InnerOrchestration = orchestration;
-                    s_factories[Descriptor] = sp => (TaskOrchestration)sp.GetRequiredService(Descriptor.Type);
+                    s_factories.TryAdd(Descriptor, sp => (TaskOrchestration)sp.GetRequiredService(Descriptor.Type));
                     return; // already created it this time, so just return now.
                 }
                 else
@@ -77,6 +77,7 @@ namespace DurableTask.DependencyInjection.Orchestrations
                 // While this looks wrong to not await this task before disposing the scope,
                 // DurableTask orchestrations are never resumed after yielding. They will only
                 // be replayed from scratch.
+                context = new WrapperOrchestrationContext(context);
                 return InnerOrchestration.Execute(context, input);
             }
         }
@@ -92,6 +93,7 @@ namespace DurableTask.DependencyInjection.Orchestrations
         public override void RaiseEvent(OrchestrationContext context, string name, string input)
         {
             CheckInnerOrchestration();
+            context = new WrapperOrchestrationContext(context);
             InnerOrchestration.RaiseEvent(context, name, input);
         }
 

--- a/src/DurableTask.DependencyInjection/src/Orchestrations/WrapperOrchestrationContext.cs
+++ b/src/DurableTask.DependencyInjection/src/Orchestrations/WrapperOrchestrationContext.cs
@@ -1,0 +1,224 @@
+﻿// Copyright (c) Jacob Viau. All rights reserved.
+// Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using DurableTask.Core;
+
+namespace DurableTask.DependencyInjection.Orchestrations
+{
+    /// <summary>
+    /// A custom orchestration context that enables open-generic support. Primarily, it retains type info when
+    /// scheduling closed generic types (so they can be reconstructed on the worker).
+    /// </summary>
+    internal class WrapperOrchestrationContext : OrchestrationContext
+    {
+        private readonly OrchestrationContext _innerContext;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WrapperOrchestrationContext"/> class.
+        /// </summary>
+        /// <param name="innerContext">The inner context to wrap.</param>
+        public WrapperOrchestrationContext(OrchestrationContext innerContext)
+        {
+            _innerContext = Check.NotNull(innerContext, nameof(innerContext));
+            OrchestrationInstance = _innerContext.OrchestrationInstance;
+            IsReplaying = _innerContext.IsReplaying;
+            MessageDataConverter = _innerContext.MessageDataConverter;
+            ErrorDataConverter = _innerContext.ErrorDataConverter;
+        }
+
+        /// <inheritdoc/>
+        public override DateTime CurrentUtcDateTime => _innerContext.CurrentUtcDateTime;
+
+        /// <inheritdoc/>
+        public override void ContinueAsNew(object input)
+        {
+            UpdateInnerProperties();
+            _innerContext.ContinueAsNew(input);
+        }
+
+        /// <inheritdoc/>
+        public override void ContinueAsNew(string newVersion, object input)
+        {
+            UpdateInnerProperties();
+            _innerContext.ContinueAsNew(newVersion, input);
+        }
+
+        /// <inheritdoc/>
+        public override Task<T> CreateSubOrchestrationInstance<T>(string name, string version, object input)
+        {
+            UpdateInnerProperties();
+            return _innerContext.CreateSubOrchestrationInstance<T>(name, version, input);
+        }
+
+        /// <inheritdoc/>
+        public override Task<T> CreateSubOrchestrationInstance<T>(
+            string name, string version, string instanceId, object input)
+        {
+            UpdateInnerProperties();
+            return _innerContext.CreateSubOrchestrationInstance<T>(name, version, instanceId, input);
+        }
+
+        /// <inheritdoc/>
+        public override Task<T> CreateSubOrchestrationInstance<T>(
+            string name, string version, string instanceId, object input, IDictionary<string, string> tags)
+        {
+            UpdateInnerProperties();
+            return _innerContext.CreateSubOrchestrationInstance<T>(name, version, instanceId, input, tags);
+        }
+
+        /// <inheritdoc/>
+        public override Task<T> CreateTimer<T>(DateTime fireAt, T state)
+        {
+            UpdateInnerProperties();
+            return _innerContext.CreateTimer(fireAt, state);
+        }
+
+        /// <inheritdoc/>
+        public override Task<T> CreateTimer<T>(DateTime fireAt, T state, CancellationToken cancelToken)
+        {
+            UpdateInnerProperties();
+            return _innerContext.CreateTimer(fireAt, state, cancelToken);
+        }
+
+        /// <inheritdoc/>
+        public override Task<TResult> ScheduleTask<TResult>(string name, string version, params object[] parameters)
+        {
+            UpdateInnerProperties();
+            return _innerContext.ScheduleTask<TResult>(name, version, parameters);
+        }
+
+        /// <inheritdoc/>
+        public override void SendEvent(OrchestrationInstance orchestrationInstance, string eventName, object eventData)
+        {
+            UpdateInnerProperties();
+            _innerContext.SendEvent(orchestrationInstance, eventName, eventData);
+        }
+
+        /// <inheritdoc/>
+        public override Task<TResult> ScheduleTask<TResult>(Type activityType, params object[] parameters)
+        {
+            UpdateInnerProperties();
+            return ScheduleTask<TResult>(
+                GenericNameHelper.GetDefaultName(activityType),
+                NameVersionHelper.GetDefaultVersion(activityType),
+                parameters);
+        }
+
+        /// <inheritdoc/>
+        public override Task<T> ScheduleWithRetry<T>(
+            Type taskActivityType, RetryOptions retryOptions, params object[] parameters)
+        {
+            UpdateInnerProperties();
+            return ScheduleWithRetry<T>(
+                GenericNameHelper.GetDefaultName(taskActivityType),
+                NameVersionHelper.GetDefaultVersion(taskActivityType),
+                retryOptions,
+                parameters);
+        }
+
+        /// <inheritdoc/>
+        public override Task<T> CreateSubOrchestrationInstance<T>(Type orchestrationType, object input)
+        {
+            UpdateInnerProperties();
+            return CreateSubOrchestrationInstance<T>(
+                GenericNameHelper.GetDefaultName(orchestrationType),
+                NameVersionHelper.GetDefaultVersion(orchestrationType),
+                input);
+        }
+
+        /// <inheritdoc/>
+        public override Task<T> CreateSubOrchestrationInstance<T>(
+            Type orchestrationType, string instanceId, object input)
+        {
+            UpdateInnerProperties();
+            return CreateSubOrchestrationInstance<T>(
+                GenericNameHelper.GetDefaultName(orchestrationType),
+                NameVersionHelper.GetDefaultVersion(orchestrationType),
+                instanceId,
+                input);
+        }
+
+        /// <inheritdoc/>
+        public override Task<T> CreateSubOrchestrationInstanceWithRetry<T>(
+            Type orchestrationType, RetryOptions retryOptions, object input)
+        {
+            UpdateInnerProperties();
+            return CreateSubOrchestrationInstanceWithRetry<T>(
+                GenericNameHelper.GetDefaultName(orchestrationType),
+                NameVersionHelper.GetDefaultVersion(orchestrationType),
+                retryOptions,
+                input);
+        }
+
+        /// <inheritdoc/>
+        public override Task<T> CreateSubOrchestrationInstanceWithRetry<T>(
+            Type orchestrationType, string instanceId, RetryOptions retryOptions, object input)
+        {
+            UpdateInnerProperties();
+            return CreateSubOrchestrationInstanceWithRetry<T>(
+                GenericNameHelper.GetDefaultName(orchestrationType),
+                NameVersionHelper.GetDefaultVersion(orchestrationType),
+                instanceId,
+                retryOptions,
+                input);
+        }
+
+        /// <inheritdoc/>
+        public override T CreateClient<T>()
+        {
+            UpdateInnerProperties();
+            return _innerContext.CreateClient<T>();
+        }
+
+        /// <inheritdoc/>
+        public override T CreateClient<T>(bool useFullyQualifiedMethodNames)
+        {
+            UpdateInnerProperties();
+            return _innerContext.CreateClient<T>(useFullyQualifiedMethodNames);
+        }
+
+        /// <inheritdoc/>
+        public override T CreateRetryableClient<T>(RetryOptions retryOptions)
+        {
+            UpdateInnerProperties();
+            return _innerContext.CreateRetryableClient<T>(retryOptions);
+        }
+
+        /// <inheritdoc/>
+        public override T CreateRetryableClient<T>(RetryOptions retryOptions, bool useFullyQualifiedMethodNames)
+        {
+            UpdateInnerProperties();
+            return _innerContext.CreateRetryableClient<T>(retryOptions, useFullyQualifiedMethodNames);
+        }
+
+        /// <inheritdoc/>
+        public override Task<T> CreateSubOrchestrationInstanceWithRetry<T>(
+            string name, string version, RetryOptions retryOptions, object input)
+        {
+            UpdateInnerProperties();
+            return _innerContext.CreateSubOrchestrationInstanceWithRetry<T>(name, version, retryOptions, input);
+        }
+
+        /// <inheritdoc/>
+        public override Task<T> CreateSubOrchestrationInstanceWithRetry<T>(
+            string name, string version, string instanceId, RetryOptions retryOptions, object input)
+        {
+            UpdateInnerProperties();
+            return _innerContext.CreateSubOrchestrationInstanceWithRetry<T>(
+                name, version, instanceId, retryOptions, input);
+        }
+
+        private void UpdateInnerProperties()
+        {
+            // We have no way to hook in to the public setter of these properties to also set it on the wrapped context.
+            // Instead, we will have to update these properties on *every* call to the wrapped context, to ensure it is
+            // up to date.
+            _innerContext.ErrorDataConverter = ErrorDataConverter;
+            _innerContext.MessageDataConverter = MessageDataConverter;
+        }
+    }
+}

--- a/src/DurableTask.DependencyInjection/src/Validation/Check.cs
+++ b/src/DurableTask.DependencyInjection/src/Validation/Check.cs
@@ -2,6 +2,7 @@
 // Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Globalization;
 using DurableTask.DependencyInjection.Properties;
 
 namespace DurableTask
@@ -11,6 +12,22 @@ namespace DurableTask
     /// </summary>
     internal static class Check
     {
+        /// <summary>
+        /// Throws an <see cref="ArgumentException"/> in the condition is false.
+        /// </summary>
+        /// <param name="condition">The condition to evaluate.</param>
+        /// <param name="name">The parameter name.</param>
+        /// <param name="message">The error message.</param>
+        /// <param name="args">The message args for formatting.</param>
+        public static void Argument(bool condition, string name, string message, params object[] args)
+        {
+            args ??= Array.Empty<object>();
+            if (!condition)
+            {
+                throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, message, args), name);
+            }
+        }
+
         /// <summary>
         /// Checks in the provided element is null, throwing if it is.
         /// Throws <see cref="ArgumentException" /> if the conditions are not met.

--- a/src/DurableTask.DependencyInjection/test/Activities/ActivityObjectCreatorTests.cs
+++ b/src/DurableTask.DependencyInjection/test/Activities/ActivityObjectCreatorTests.cs
@@ -1,0 +1,91 @@
+﻿// Copyright (c) Jacob Viau. All rights reserved.
+// Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
+
+using System;
+using DurableTask.Core;
+using FluentAssertions;
+using Xunit;
+
+namespace DurableTask.DependencyInjection.Activities.Tests
+{
+    public class ActivityObjectCreatorTests
+    {
+        [Fact]
+        public void Ctor_NullDescriptor_Throws()
+        {
+            Action act = () => new ActivityObjectCreator(null);
+            act.Should().ThrowExactly<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Create_WrapperCreated()
+        {
+            var descriptor = TaskActivityDescriptor.Create<TestActivity>();
+            var creator = new ActivityObjectCreator(descriptor);
+            TaskActivity activity = creator.Create();
+            activity.Should().NotBeNull();
+            activity.Should().BeOfType<WrapperActivity>()
+                .Which.Descriptor.Should().Be(descriptor);
+        }
+
+        [Fact]
+        public void Create_GenericDef_Throws()
+        {
+            var descriptor = new TaskActivityDescriptor(typeof(TestActivity<>));
+            var creator = new ActivityObjectCreator(descriptor);
+            Action act = () => creator.Create();
+            act.Should().ThrowExactly<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void CreateWithName_NotGeneric_Throws()
+        {
+            var descriptor = TaskActivityDescriptor.Create<TestActivity>();
+            var creator = new ActivityObjectCreator(descriptor);
+            Action act = () => creator.Create("Some name");
+            act.Should().ThrowExactly<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void CreateWithName_GenericDef_ArgNull_Throws()
+        {
+            var descriptor = new TaskActivityDescriptor(typeof(TestActivity<>));
+            var creator = new ActivityObjectCreator(descriptor);
+            Action act = () => creator.Create(null);
+            act.Should().ThrowExactly<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void CreateWithName_GenericDef_TypeIssue_Throws()
+        {
+            var descriptor = new TaskActivityDescriptor(typeof(TestActivity<>));
+            var creator = new ActivityObjectCreator(descriptor);
+            Action act = () => creator.Create("Invalid name");
+            act.Should().ThrowExactly<TypeLoadException>();
+        }
+
+        [Fact]
+        public void CreateWithName_GenericDef_WrapperCreated()
+        {
+            var descriptor = new TaskActivityDescriptor(typeof(TestActivity<>));
+            var type = typeof(TestActivity<object>);
+            var creator = new ActivityObjectCreator(descriptor);
+            TaskActivity activity = creator.Create(type.FullName);
+            activity.Should().NotBeNull();
+            activity.Should().BeOfType<WrapperActivity>()
+                .Which.Descriptor.Type.Should().Be(type);
+        }
+
+        private class TestActivity : TaskActivity
+        {
+            public override string Run(TaskContext context, string input)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class TestActivity<T> : TestActivity
+        {
+        }
+    }
+}

--- a/src/DurableTask.DependencyInjection/test/Activities/TaskActivityDescriptorTests.cs
+++ b/src/DurableTask.DependencyInjection/test/Activities/TaskActivityDescriptorTests.cs
@@ -1,0 +1,140 @@
+﻿// Copyright (c) Jacob Viau. All rights reserved.
+// Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using DurableTask.Core;
+using FluentAssertions;
+using Xunit;
+
+namespace DurableTask.DependencyInjection.Activitys.Tests
+{
+    public class TaskActivityDescriptorTests
+    {
+        [Fact]
+        public void Ctor_NullType_Throws()
+        {
+            Action act = () => new TaskActivityDescriptor((Type)null);
+            act.Should().ThrowExactly<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Ctor_NullMethodInfo_Throws()
+        {
+            Action act = () => new TaskActivityDescriptor((MethodInfo)null);
+            act.Should().ThrowExactly<ArgumentNullException>();
+        }
+
+        [Theory]
+        [InlineData(typeof(object))]
+        [InlineData(typeof(TaskActivity))]
+        public void Ctor_InvalidType_Throws(Type type)
+        {
+            Action act = () => new TaskActivityDescriptor(type);
+            act.Should().ThrowExactly<ArgumentException>();
+        }
+
+        [Theory]
+        [InlineData(typeof(TestActivity))]
+        [InlineData(typeof(TestActivity<>))]
+        [InlineData(typeof(TestActivity<object>))]
+        public void Ctor_Type_DefaultNameVersion(Type type)
+        {
+            var descriptor = new TaskActivityDescriptor(type);
+            descriptor.Should().NotBeNull();
+            descriptor.Method.Should().BeNull();
+            descriptor.Type.Should().Be(type);
+            descriptor.Name.Should().Be(type.FullName);
+            descriptor.Version.Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData(typeof(TestActivity))]
+        [InlineData(typeof(TestActivity<>))]
+        [InlineData(typeof(TestActivity<object>))]
+        public void Ctor_Type_SuppliedNameVersion(Type type)
+        {
+            const string name = "CustomName";
+            const string version = "CustomVersion";
+            var descriptor = new TaskActivityDescriptor(type, name, version);
+            descriptor.Should().NotBeNull();
+            descriptor.Method.Should().BeNull();
+            descriptor.Type.Should().Be(type);
+            descriptor.Name.Should().Be(name);
+            descriptor.Version.Should().Be(version);
+        }
+
+        [Fact]
+        public void Ctor_MethodInfo_DefaultNameVersion()
+        {
+            var methodInfo = typeof(IMyServce).GetMethod(nameof(IMyServce.SomethingAsync));
+            var descriptor = new TaskActivityDescriptor(methodInfo);
+            descriptor.Type.Should().BeNull();
+            descriptor.Method.Should().BeSameAs(methodInfo);
+            descriptor.Name.Should().Be(NameVersionHelper.GetDefaultName(methodInfo));
+            descriptor.Version.Should().Be(NameVersionHelper.GetDefaultVersion(methodInfo));
+        }
+
+        [Fact]
+        public void Ctor_MethodInfo_SuppliedNameVersion()
+        {
+            const string name = "CustomName";
+            const string version = "CustomVersion";
+            var methodInfo = typeof(IMyServce).GetMethod(nameof(IMyServce.SomethingAsync));
+            var descriptor = new TaskActivityDescriptor(methodInfo, name, version);
+            descriptor.Type.Should().BeNull();
+            descriptor.Method.Should().BeSameAs(methodInfo);
+            descriptor.Name.Should().Be(name);
+            descriptor.Version.Should().Be(version);
+        }
+
+        [Fact]
+        public void Create_ConcreteType_Succeeds()
+        {
+            var descriptor = TaskActivityDescriptor.Create<TestActivity>();
+            descriptor.Should().NotBeNull();
+            descriptor.Method.Should().BeNull();
+            descriptor.Type.Should().Be(typeof(TestActivity));
+            descriptor.Name.Should().Be(typeof(TestActivity).FullName);
+            descriptor.Version.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Create_SuppliedNameVersion()
+        {
+            const string name = "CustomName";
+            const string version = "CustomVersion";
+            var descriptor = TaskActivityDescriptor.Create<TestActivity>(name, version);
+            descriptor.Should().NotBeNull();
+            descriptor.Method.Should().BeNull();
+            descriptor.Type.Should().Be(typeof(TestActivity));
+            descriptor.Name.Should().Be(name);
+            descriptor.Version.Should().Be(version);
+        }
+
+        [Fact]
+        public void Create_AbstractType_Fails()
+        {
+            Action act = () => TaskActivityDescriptor.Create<TaskActivity>();
+            act.Should().ThrowExactly<ArgumentException>();
+        }
+
+        private class TestActivity : TaskActivity
+        {
+            public override string Run(TaskContext context, string input)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class TestActivity<T> : TestActivity
+        {
+        }
+
+        private interface IMyServce
+        {
+            Task<string> SomethingAsync();
+        }
+    }
+}

--- a/src/DurableTask.DependencyInjection/test/Activities/TaskHubWorkerBuilderActivityExtensionsTests.cs
+++ b/src/DurableTask.DependencyInjection/test/Activities/TaskHubWorkerBuilderActivityExtensionsTests.cs
@@ -9,7 +9,7 @@ using Moq;
 using Xunit;
 using static DurableTask.TestHelpers;
 
-namespace DurableTask.DependencyInjection.Tests.Extensions
+namespace DurableTask.DependencyInjection.Activities.Tests
 {
     public class TaskHubWorkerBuilderActivityExtensionsTests
     {

--- a/src/DurableTask.DependencyInjection/test/Activities/WrapperActivityTests.cs
+++ b/src/DurableTask.DependencyInjection/test/Activities/WrapperActivityTests.cs
@@ -1,7 +1,9 @@
-﻿using System;
+﻿// Copyright (c) Jacob Viau. All rights reserved.
+// Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Threading.Tasks;
 using DurableTask.Core;
-using DurableTask.DependencyInjection.Activities;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
@@ -10,7 +12,7 @@ using Newtonsoft.Json.Linq;
 using Xunit;
 using static DurableTask.TestHelpers;
 
-namespace DurableTask.DependencyInjection.Tests.Activities
+namespace DurableTask.DependencyInjection.Activities.Tests
 {
     public class WrapperActivityTests
     {

--- a/src/DurableTask.DependencyInjection/test/DefaultTaskHubWorkerBuilderTests.cs
+++ b/src/DurableTask.DependencyInjection/test/DefaultTaskHubWorkerBuilderTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Jacob Viau. All rights reserved.
+// Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Threading.Tasks;
 using DurableTask.Core;
 using DurableTask.Core.Middleware;

--- a/src/DurableTask.DependencyInjection/test/Extensions/AssemblyExtensionTests.cs
+++ b/src/DurableTask.DependencyInjection/test/Extensions/AssemblyExtensionTests.cs
@@ -1,10 +1,12 @@
-﻿using System;
+﻿// Copyright (c) Jacob Viau. All rights reserved.
+// Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Collections.Generic;
-using DurableTask.DependencyInjection.Extensions;
 using FluentAssertions;
 using Xunit;
 
-namespace DurableTask.DependencyInjection.Tests.Extensions
+namespace DurableTask.DependencyInjection.Extensions.Tests
 {
     public class AssemblyExtensionTests
     {

--- a/src/DurableTask.DependencyInjection/test/Extensions/TaskHubServiceCollectionExtensionsTests.cs
+++ b/src/DurableTask.DependencyInjection/test/Extensions/TaskHubServiceCollectionExtensionsTests.cs
@@ -1,12 +1,14 @@
-﻿using System;
-using System.Linq;
+﻿// Copyright (c) Jacob Viau. All rights reserved.
+// Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
+
+using System;
 using DurableTask.Core;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using static DurableTask.TestHelpers;
 
-namespace DurableTask.DependencyInjection.Tests.Extensions
+namespace DurableTask.DependencyInjection.Extensions.Tests
 {
     public class TaskHubServiceCollectionExtensionsTests
     {

--- a/src/DurableTask.DependencyInjection/test/Extensions/TaskHubWorkerBuilderExtensionsTests.cs
+++ b/src/DurableTask.DependencyInjection/test/Extensions/TaskHubWorkerBuilderExtensionsTests.cs
@@ -1,8 +1,10 @@
-﻿using System;
+﻿// Copyright (c) Jacob Viau. All rights reserved.
+// Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Linq;
 using DurableTask.Core;
 using FluentAssertions;
-using FluentAssertions.Common;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -10,7 +12,7 @@ using Moq;
 using Xunit;
 using static DurableTask.TestHelpers;
 
-namespace DurableTask.DependencyInjection.Tests.Extensions
+namespace DurableTask.DependencyInjection.Extensions.Tests
 {
     public class TaskHubWorkerBuilderExtensionsTests
     {

--- a/src/DurableTask.DependencyInjection/test/GenericObjectManagerTests.cs
+++ b/src/DurableTask.DependencyInjection/test/GenericObjectManagerTests.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) Jacob Viau. All rights reserved.
+// Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
+
+using System;
+using DurableTask.Core;
+using DurableTask.DependencyInjection.Activities;
+using FluentAssertions;
+using Xunit;
+
+namespace DurableTask.DependencyInjection.Tests
+{
+    public class GenericObjectManagerTests
+    {
+        private static readonly TaskActivityDescriptor s_descriptor = TaskActivityDescriptor.Create<TestActivity>();
+
+        [Fact]
+        public void Add_NotExists_Succeeds()
+        {
+            var manager = new GenericObjectManager<TaskActivity>();
+            manager.Add(new ActivityObjectCreator(s_descriptor));
+        }
+
+        [Fact]
+        public void Add_Exists_Throws()
+        {
+            var manager = new GenericObjectManager<TaskActivity>();
+            manager.Add(new ActivityObjectCreator(s_descriptor));
+
+            Action act = () => manager.Add(new ActivityObjectCreator(s_descriptor));
+            act.Should().Throw<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void Create_NotExists_Null()
+        {
+            var manager = new GenericObjectManager<TaskActivity>();
+            TaskActivity activity = manager.GetObject("DNE", "");
+            activity.Should().BeNull();
+        }
+
+        [Fact]
+        public void Create_Exists_NotNull()
+        {
+            var manager = new GenericObjectManager<TaskActivity>();
+            manager.Add(new ActivityObjectCreator(s_descriptor));
+            TaskActivity activity = manager.GetObject(s_descriptor.Name, s_descriptor.Version);
+            activity.Should().NotBeNull();
+            activity.As<WrapperActivity>().Descriptor.Type.Should().Be(s_descriptor.Type);
+        }
+
+        [Theory]
+        [InlineData(typeof(TestActivity<object>))]
+        [InlineData(typeof(TestActivity<int>))]
+        [InlineData(typeof(TestActivity<SomeClass>))]
+        public void Create_OpenGeneric_NotNull(Type type)
+        {
+            var manager = new GenericObjectManager<TaskActivity>();
+            manager.Add(new ActivityObjectCreator(new TaskActivityDescriptor(typeof(TestActivity<>))));
+            TaskActivity activity = manager.GetObject(type.FullName, string.Empty);
+            activity.Should().NotBeNull();
+            activity.As<WrapperActivity>().Descriptor.Type.Should().Be(type);
+        }
+
+        [Fact]
+        public void Create_ClosedGeneric_NotNull()
+        {
+            var descriptor = TaskActivityDescriptor.Create<TestActivity<object>>();
+            var manager = new GenericObjectManager<TaskActivity>();
+            manager.Add(new ActivityObjectCreator(descriptor));
+            TaskActivity activity = manager.GetObject(descriptor.Name, descriptor.Version);
+            activity.Should().NotBeNull();
+            activity.As<WrapperActivity>().Descriptor.Type.Should().Be(descriptor.Type);
+
+            TaskActivity activity2 = manager.GetObject(typeof(TestActivity<int>).FullName, descriptor.Version);
+            activity2.Should().BeNull();
+        }
+
+        private class TestActivity : TaskActivity
+        {
+            public override string Run(TaskContext context, string input)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class TestActivity<T> : TestActivity
+        {
+        }
+
+        private class SomeClass
+        {
+        }
+    }
+}

--- a/src/DurableTask.DependencyInjection/test/Middleware/ServiceProviderActivityMiddlewareTests.cs
+++ b/src/DurableTask.DependencyInjection/test/Middleware/ServiceProviderActivityMiddlewareTests.cs
@@ -1,15 +1,17 @@
-﻿using System;
+﻿// Copyright (c) Jacob Viau. All rights reserved.
+// Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Threading.Tasks;
 using DurableTask.Core;
 using DurableTask.Core.Middleware;
 using DurableTask.DependencyInjection.Activities;
-using DurableTask.DependencyInjection.Middleware;
 using FluentAssertions;
 using Moq;
 using Xunit;
 using static DurableTask.TestHelpers;
 
-namespace DurableTask.DependencyInjection.Tests.Middleware
+namespace DurableTask.DependencyInjection.Middleware.Tests
 {
     public class ServiceProviderActivityMiddlewareTests
     {

--- a/src/DurableTask.DependencyInjection/test/Middleware/ServiceProviderOrchestrationMiddlewareTests.cs
+++ b/src/DurableTask.DependencyInjection/test/Middleware/ServiceProviderOrchestrationMiddlewareTests.cs
@@ -1,15 +1,17 @@
-﻿using System;
+﻿// Copyright (c) Jacob Viau. All rights reserved.
+// Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Threading.Tasks;
 using DurableTask.Core;
 using DurableTask.Core.Middleware;
-using DurableTask.DependencyInjection.Middleware;
 using DurableTask.DependencyInjection.Orchestrations;
 using FluentAssertions;
 using Moq;
 using Xunit;
 using static DurableTask.TestHelpers;
 
-namespace DurableTask.DependencyInjection.Tests.Middleware
+namespace DurableTask.DependencyInjection.Middleware.Tests
 {
     public class ServiceProviderOrchestrationMiddlewareTests
     {

--- a/src/DurableTask.DependencyInjection/test/Middleware/TaskMiddlewareRunnerTests.cs
+++ b/src/DurableTask.DependencyInjection/test/Middleware/TaskMiddlewareRunnerTests.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// Copyright (c) Jacob Viau. All rights reserved.
+// Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Threading.Tasks;
-using DurableTask.Core;
 using DurableTask.Core.Middleware;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/DurableTask.DependencyInjection/test/OrchestrationScopeTests.cs
+++ b/src/DurableTask.DependencyInjection/test/OrchestrationScopeTests.cs
@@ -1,7 +1,8 @@
-﻿using System;
+﻿// Copyright (c) Jacob Viau. All rights reserved.
+// Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
-using DurableTask.Core;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;

--- a/src/DurableTask.DependencyInjection/test/Orchestrations/OrchestrationObjectCreatorTests.cs
+++ b/src/DurableTask.DependencyInjection/test/Orchestrations/OrchestrationObjectCreatorTests.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) Jacob Viau. All rights reserved.
+// Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading.Tasks;
+using DurableTask.Core;
+using FluentAssertions;
+using Xunit;
+
+namespace DurableTask.DependencyInjection.Orchestrations.Tests
+{
+    public class OrchestrationObjectCreatorTests
+    {
+        [Fact]
+        public void Ctor_NullDescriptor_Throws()
+        {
+            Action act = () => new OrchestrationObjectCreator(null);
+            act.Should().ThrowExactly<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Create_WrapperCreated()
+        {
+            var descriptor = TaskOrchestrationDescriptor.Create<TestOrchestration>();
+            var creator = new OrchestrationObjectCreator(descriptor);
+            TaskOrchestration Orchestration = creator.Create();
+            Orchestration.Should().NotBeNull();
+            Orchestration.Should().BeOfType<WrapperOrchestration>()
+                .Which.Descriptor.Should().Be(descriptor);
+        }
+
+        [Fact]
+        public void Create_GenericDef_Throws()
+        {
+            var descriptor = new TaskOrchestrationDescriptor(typeof(TestOrchestration<>));
+            var creator = new OrchestrationObjectCreator(descriptor);
+            Action act = () => creator.Create();
+            act.Should().ThrowExactly<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void CreateWithName_NotGeneric_Throws()
+        {
+            var descriptor = TaskOrchestrationDescriptor.Create<TestOrchestration>();
+            var creator = new OrchestrationObjectCreator(descriptor);
+            Action act = () => creator.Create("Some name");
+            act.Should().ThrowExactly<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void CreateWithName_GenericDef_ArgNull_Throws()
+        {
+            var descriptor = new TaskOrchestrationDescriptor(typeof(TestOrchestration<>));
+            var creator = new OrchestrationObjectCreator(descriptor);
+            Action act = () => creator.Create(null);
+            act.Should().ThrowExactly<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void CreateWithName_GenericDef_TypeIssue_Throws()
+        {
+            var descriptor = new TaskOrchestrationDescriptor(typeof(TestOrchestration<>));
+            var creator = new OrchestrationObjectCreator(descriptor);
+            Action act = () => creator.Create("Invalid name");
+            act.Should().ThrowExactly<TypeLoadException>();
+        }
+
+        [Fact]
+        public void CreateWithName_GenericDef_WrapperCreated()
+        {
+            var descriptor = new TaskOrchestrationDescriptor(typeof(TestOrchestration<>));
+            var type = typeof(TestOrchestration<object>);
+            var creator = new OrchestrationObjectCreator(descriptor);
+            TaskOrchestration Orchestration = creator.Create(type.FullName);
+            Orchestration.Should().NotBeNull();
+            Orchestration.Should().BeOfType<WrapperOrchestration>()
+                .Which.Descriptor.Type.Should().Be(type);
+        }
+
+        private class TestOrchestration : TaskOrchestration
+        {
+            public override Task<string> Execute(OrchestrationContext context, string input)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override string GetStatus()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void RaiseEvent(OrchestrationContext context, string name, string input)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class TestOrchestration<T> : TestOrchestration
+        {
+        }
+    }
+}

--- a/src/DurableTask.DependencyInjection/test/Orchestrations/TaskHubWorkerBuilderOrchestrationExtensionsTests.cs
+++ b/src/DurableTask.DependencyInjection/test/Orchestrations/TaskHubWorkerBuilderOrchestrationExtensionsTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Jacob Viau. All rights reserved.
+// Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using DurableTask.Core;
@@ -9,7 +12,7 @@ using Moq;
 using Xunit;
 using static DurableTask.TestHelpers;
 
-namespace DurableTask.DependencyInjection.Tests.Extensions
+namespace DurableTask.DependencyInjection.Orchestrations.Tests
 {
     public class TaskHubWorkerBuilderOrchestrationExtensionsTests
     {

--- a/src/DurableTask.DependencyInjection/test/Orchestrations/TaskOrchestrationDescriptorTests.cs
+++ b/src/DurableTask.DependencyInjection/test/Orchestrations/TaskOrchestrationDescriptorTests.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (c) Jacob Viau. All rights reserved.
+// Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading.Tasks;
+using DurableTask.Core;
+using FluentAssertions;
+using Xunit;
+
+namespace DurableTask.DependencyInjection.Orchestrations.Tests
+{
+    public class TaskOrchestrationDescriptorTests
+    {
+        [Fact]
+        public void Ctor_NullType_Throws()
+        {
+            Action act = () => new TaskOrchestrationDescriptor(null);
+            act.Should().ThrowExactly<ArgumentNullException>();
+        }
+
+        [Theory]
+        [InlineData(typeof(object))]
+        [InlineData(typeof(TaskOrchestration))]
+        public void Ctor_InvalidType_Throws(Type type)
+        {
+            Action act = () => new TaskOrchestrationDescriptor(type);
+            act.Should().ThrowExactly<ArgumentException>();
+        }
+
+        [Theory]
+        [InlineData(typeof(TestOrchestration))]
+        [InlineData(typeof(TestOrchestration<>))]
+        [InlineData(typeof(TestOrchestration<object>))]
+        public void Ctor_DefaultNameVersion(Type type)
+        {
+            var descriptor = new TaskOrchestrationDescriptor(type);
+            descriptor.Should().NotBeNull();
+            descriptor.Type.Should().Be(type);
+            descriptor.Name.Should().Be(type.FullName);
+            descriptor.Version.Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData(typeof(TestOrchestration))]
+        [InlineData(typeof(TestOrchestration<>))]
+        [InlineData(typeof(TestOrchestration<object>))]
+        public void Ctor_SuppliedNameVersion(Type type)
+        {
+            const string name = "CustomName";
+            const string version = "CustomVersion";
+            var descriptor = new TaskOrchestrationDescriptor(type, name, version);
+            descriptor.Should().NotBeNull();
+            descriptor.Type.Should().Be(type);
+            descriptor.Name.Should().Be(name);
+            descriptor.Version.Should().Be(version);
+        }
+
+        [Fact]
+        public void Create_ConcreteType_Succeeds()
+        {
+            var descriptor = TaskOrchestrationDescriptor.Create<TestOrchestration>();
+            descriptor.Should().NotBeNull();
+            descriptor.Type.Should().Be(typeof(TestOrchestration));
+            descriptor.Name.Should().Be(typeof(TestOrchestration).FullName);
+            descriptor.Version.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Create_SuppliedNameVersion()
+        {
+            const string name = "CustomName";
+            const string version = "CustomVersion";
+            var descriptor = TaskOrchestrationDescriptor.Create<TestOrchestration>(name, version);
+            descriptor.Should().NotBeNull();
+            descriptor.Type.Should().Be(typeof(TestOrchestration));
+            descriptor.Name.Should().Be(name);
+            descriptor.Version.Should().Be(version);
+        }
+
+        [Fact]
+        public void Create_AbstractType_Fails()
+        {
+            Action act = () => TaskOrchestrationDescriptor.Create<TaskOrchestration>();
+            act.Should().ThrowExactly<ArgumentException>();
+        }
+
+        private class TestOrchestration : TaskOrchestration
+        {
+            public override Task<string> Execute(OrchestrationContext context, string input)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override string GetStatus()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void RaiseEvent(OrchestrationContext context, string name, string input)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class TestOrchestration<T> : TestOrchestration
+        {
+        }
+    }
+}

--- a/src/DurableTask.DependencyInjection/test/Orchestrations/WrapperOrchestrationTests.cs
+++ b/src/DurableTask.DependencyInjection/test/Orchestrations/WrapperOrchestrationTests.cs
@@ -1,16 +1,18 @@
-﻿using System;
+﻿// Copyright (c) Jacob Viau. All rights reserved.
+// Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using DurableTask.Core;
-using DurableTask.DependencyInjection.Orchestrations;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit;
 using static DurableTask.TestHelpers;
 
-namespace DurableTask.DependencyInjection.Tests.Activities
+namespace DurableTask.DependencyInjection.Orchestrations.Tests
 {
     public class WrapperOrchestrationTests
     {
@@ -86,7 +88,7 @@ namespace DurableTask.DependencyInjection.Tests.Activities
                 (wrapper, result) =>
                 {
                     result.Should().BeOneOf(Input, $"\"{Input}\"");
-                    InvokedContext.Should().Be(s_orchestrationContext);
+                    InvokedContext.Should().BeOfType<WrapperOrchestrationContext>();
                     InvokedInput.Should().BeOneOf(Input, $"\"{Input}\"");
                 });
 

--- a/src/DurableTask.DependencyInjection/test/Orchestrations/WrapperOrchestrationTests.cs
+++ b/src/DurableTask.DependencyInjection/test/Orchestrations/WrapperOrchestrationTests.cs
@@ -133,7 +133,7 @@ namespace DurableTask.DependencyInjection.Orchestrations.Tests
                 (wrapper, _) =>
                 {
                     EventRaised.Should().Be(Event);
-                    InvokedContext.Should().Be(s_orchestrationContext);
+                    InvokedContext.Should().BeOfType<WrapperOrchestrationContext>();
                     InvokedInput.Should().BeOneOf(Input, $"\"{Input}\"");
                 });
 

--- a/src/DurableTask.DependencyInjection/test/TestHelpers.cs
+++ b/src/DurableTask.DependencyInjection/test/TestHelpers.cs
@@ -1,6 +1,8 @@
-﻿using System;
+﻿// Copyright (c) Jacob Viau. All rights reserved.
+// Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Threading.Tasks;
-using FluentAssertions;
 
 namespace DurableTask
 {

--- a/src/DurableTask.Hosting/test/Extensions/TaskHubHostBuilderExtensionsTests.cs
+++ b/src/DurableTask.Hosting/test/Extensions/TaskHubHostBuilderExtensionsTests.cs
@@ -1,11 +1,14 @@
-﻿using System;
+﻿// Copyright (c) Jacob Viau. All rights reserved.
+// Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
+
+using System;
 using DurableTask.DependencyInjection;
 using FluentAssertions;
 using Microsoft.Extensions.Hosting;
 using Xunit;
 using static DurableTask.TestHelpers;
 
-namespace DurableTask.Hosting.Tests.Extensions
+namespace DurableTask.Hosting.Extensions.Tests
 {
     public class TaskHubHostBuilderExtensionsTests
     {

--- a/src/DurableTask.Hosting/test/Functional/EndToEndTests.cs
+++ b/src/DurableTask.Hosting/test/Functional/EndToEndTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Jacob Viau. All rights reserved.
+// Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -12,7 +15,7 @@ using Microsoft.Extensions.Hosting;
 using Newtonsoft.Json;
 using Xunit;
 
-namespace DurableTask.Hosting.Tests.Functional
+namespace DurableTask.Hosting.Functional.Tests
 {
     public class EndToEndTests
     {

--- a/src/DurableTask.Hosting/test/TaskHubBackgroundServiceTests.cs
+++ b/src/DurableTask.Hosting/test/TaskHubBackgroundServiceTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Jacob Viau. All rights reserved.
+// Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using DurableTask.Core;


### PR DESCRIPTION
Adds experimental support for open generic orchestrations and activities. It is performed by registering the open generic type to the builder, then enqueueing the closed-generic type to the Context.

## Example:

``` CSharp
host.ConfigureTaskHubWorker(builder =>
{
    // ...
    builder.AddActivity(typeof(MyGenericActivity<>));
});
```

## Known Issue

`TaskHubClient` has no extensibility point to override its overloads with `Type` param to get a different task name for the type. These will potentially fail on execution due to missing assembly info. To get around it, customers should use the name/version overload and enqueue with `Type.FullName`. This will be solved with https://github.com/Azure/durabletask/pull/496. (That PR will also remove the need for the `WrapperOrchestrationContext`).

Closes #4 