### PR TITLE
Consume IOrchestrationService (and IOrchestrationServiceClient) via dependency injection

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/samples/DurableTask.Samples/bin/Debug/netcoreapp3.1/Vio.DurableTask.Samples.dll",
+            "program": "${workspaceFolder}/out/bin/Debug/DurableTask.Samples/netcoreapp2.2/Vio.DurableTask.Samples.dll",
             "args": [],
             "cwd": "${workspaceFolder}/samples/DurableTask.Samples",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -1,4 +1,6 @@
-# Release 2.0.9-preview
+# Release 2.1.0-preview
 
-- Use a short(er) type name, keeping only assembly short name (for generic params) and type name w/ namespace.
-   - This means assembly version and public key are dropped.
+- Consume `IOrchestrationService` via dependency injection.
+  - `WithOrchestrationService` now adds to `IServiceCollection` as singleton.
+  - `AddClient` now first looks for `IOrchestrationServiceClient`, then falls back to casting `IOrchestrationService`.
+  - `ITaskHubWorkerBuilder.OrchestrationService` marked as obsolete.

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -1,4 +1,4 @@
-# Release 2.1.0-preview
+# Release 2.1.2-preview
 
 - Consume `IOrchestrationService` via dependency injection.
   - `WithOrchestrationService` now adds to `IServiceCollection` as singleton.

--- a/src/DurableTask.DependencyInjection/src/DefaultTaskHubWorkerBuilder.cs
+++ b/src/DurableTask.DependencyInjection/src/DefaultTaskHubWorkerBuilder.cs
@@ -63,9 +63,9 @@ namespace DurableTask.DependencyInjection
         {
             Check.NotNull(serviceProvider, nameof(serviceProvider));
 
-            if (OrchestrationService == null)
+            if (OrchestrationService is null)
             {
-                throw new InvalidOperationException(Strings.OrchestrationInstanceNull);
+                OrchestrationService = serviceProvider.GetRequiredService<IOrchestrationService>();
             }
 
             // Verify we still have our ServiceProvider middleware

--- a/src/DurableTask.DependencyInjection/src/ITaskHubWorkerBuilder.cs
+++ b/src/DurableTask.DependencyInjection/src/ITaskHubWorkerBuilder.cs
@@ -19,8 +19,10 @@ namespace DurableTask.DependencyInjection
         IServiceCollection Services { get; }
 
         /// <summary>
-        /// Gets or sets the <see cref="IOrchestrationService"/> to use.
+        /// Gets or sets the <see cref="IOrchestrationService"/> to use. If this is null, it will be fetched from the
+        /// service provider.
         /// </summary>
+        [Obsolete("Add IOrchestrationService to the IServiceCollection as a singleton instead.")]
         IOrchestrationService OrchestrationService { get; set; }
 
         /// <summary>

--- a/src/DurableTask.DependencyInjection/src/Properties/Strings.Designer.cs
+++ b/src/DurableTask.DependencyInjection/src/Properties/Strings.Designer.cs
@@ -65,19 +65,13 @@ namespace DurableTask.DependencyInjection.Properties
                 CultureInfo.CurrentUICulture);
 
         /// <summary>
-        ///     Failed to add TaskHubClient. '{orchestrationType}' does not implement IOrchestrationServiceClient.
+        ///     Failed to add TaskHubClient. No IOrchestrationServiceClient was found in the service container and '{orchestrationType}' does not implement IOrchestrationServiceClient.
         /// </summary>
         public static string NotOrchestrationServiceClient(object orchestrationType)
             => string.Format(
                 GetString("NotOrchestrationServiceClient", nameof(orchestrationType)),
                 orchestrationType,
                 CultureInfo.CurrentUICulture);
-
-        /// <summary>
-        ///     The builder is not fully configured yet. OrchestrationService is null.
-        /// </summary>
-        public static string OrchestrationInstanceNull
-            => GetString("OrchestrationInstanceNull");
 
         /// <summary>
         ///     Scope already exists for orchestration '{orchestrationId}'.

--- a/src/DurableTask.DependencyInjection/src/Properties/Strings.resx
+++ b/src/DurableTask.DependencyInjection/src/Properties/Strings.resx
@@ -139,10 +139,7 @@
     <value>Type ['{type}'] must be an interface.</value>
   </data>
   <data name="NotOrchestrationServiceClient" xml:space="preserve">
-    <value>Failed to add TaskHubClient. '{orchestrationType}' does not implement IOrchestrationServiceClient.</value>
-  </data>
-  <data name="OrchestrationInstanceNull" xml:space="preserve">
-    <value>The builder is not fully configured yet. OrchestrationService is null.</value>
+    <value>Failed to add TaskHubClient. No IOrchestrationServiceClient was found in the service container and '{orchestrationType}' does not implement IOrchestrationServiceClient.</value>
   </data>
   <data name="ScopeAlreadyExists" xml:space="preserve">
     <value>Scope already exists for orchestration '{orchestrationId}'.</value>

--- a/src/DurableTask.DependencyInjection/test/OrchestrationScopeTests.cs
+++ b/src/DurableTask.DependencyInjection/test/OrchestrationScopeTests.cs
@@ -17,7 +17,7 @@ namespace DurableTask.DependencyInjection.Tests
         public void GetScope_ArgumentNull()
         {
             // arrange, act
-            var ex = Capture<ArgumentNullException>(
+            ArgumentNullException ex = Capture<ArgumentNullException>(
                 () => OrchestrationScope.GetScope(null));
 
             // assert
@@ -28,7 +28,7 @@ namespace DurableTask.DependencyInjection.Tests
         public void GetScope_KeyNotFound()
         {
             // arrange, act
-            var ex = Capture<KeyNotFoundException>(
+            KeyNotFoundException ex = Capture<KeyNotFoundException>(
                 () => OrchestrationScope.GetScope(Guid.NewGuid().ToString()));
 
             // assert

--- a/src/DurableTask.Hosting/test/Functional/EndToEndTests.cs
+++ b/src/DurableTask.Hosting/test/Functional/EndToEndTests.cs
@@ -36,6 +36,38 @@ namespace DurableTask.Hosting.Functional.Tests
             hostedServices.Single().Should().BeOfType(typeof(TaskHubBackgroundService));
         }
 
+        [Fact]
+        public void ConfigureTaskHubWorker_ServicesAdded2()
+        {
+            IHost host = CreateHost(
+                s => s.AddSingleton<IOrchestrationService>(new LocalOrchestrationService()),
+                _ => { });
+
+            TaskHubWorker worker = host.Services.GetService<TaskHubWorker>();
+            IEnumerable<IHostedService> hostedServices = host.Services.GetServices<IHostedService>();
+
+            worker.Should().NotBeNull();
+            hostedServices.Should().HaveCount(1);
+            hostedServices.Single().Should().BeOfType(typeof(TaskHubBackgroundService));
+        }
+
+        [Fact]
+        public void ConfigureTaskHubWorker_ServicesAdded3()
+        {
+            IHost host = CreateHost(
+                _ => { },
+#pragma warning disable CS0618 // Type or member is obsolete
+                b => b.OrchestrationService = new LocalOrchestrationService());
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            TaskHubWorker worker = host.Services.GetService<TaskHubWorker>();
+            IEnumerable<IHostedService> hostedServices = host.Services.GetServices<IHostedService>();
+
+            worker.Should().NotBeNull();
+            hostedServices.Should().HaveCount(1);
+            hostedServices.Single().Should().BeOfType(typeof(TaskHubBackgroundService));
+        }
+
         [Theory]
         [InlineData((ServiceLifetime)(-1))]
         [InlineData(ServiceLifetime.Singleton)]
@@ -46,6 +78,7 @@ namespace DurableTask.Hosting.Functional.Tests
             IHost host = CreateHost(
                 s =>
                 {
+                    s.AddSingleton<IOrchestrationService>(new LocalOrchestrationService());
                     s.AddSingleton<ExecutionTracker>();
 
                     if ((int)serviceLifetime != -1)
@@ -56,7 +89,6 @@ namespace DurableTask.Hosting.Functional.Tests
                 },
                 b =>
                 {
-                    b.WithOrchestrationService(new LocalOrchestrationService());
                     b.AddOrchestration<TestOrchestration>();
                     b.AddClient();
                 });

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.0-preview",
+  "version": "2.1-preview",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/tags/v\\d+\\.\\d+"


### PR DESCRIPTION
Consume `IOrchestrationService` via dependency injection.
  - `WithOrchestrationService` now adds to `IServiceCollection` as singleton.
  - `AddClient` now first looks for `IOrchestrationServiceClient`, then falls back to casting `IOrchestrationService`.
  - `ITaskHubWorkerBuilder.OrchestrationService` marked as obsolete.