### PR TITLE
Fix IsReplaying out of sync with inner context

### DIFF
--- a/src/DurableTask.DependencyInjection/src/Orchestrations/WrapperOrchestrationContext.cs
+++ b/src/DurableTask.DependencyInjection/src/Orchestrations/WrapperOrchestrationContext.cs
@@ -31,194 +31,225 @@ namespace DurableTask.DependencyInjection.Orchestrations
         }
 
         /// <inheritdoc/>
-        public override DateTime CurrentUtcDateTime => _innerContext.CurrentUtcDateTime;
+        public override DateTime CurrentUtcDateTime
+        {
+            get
+            {
+                PreUpdateProperties();
+                return Wrap(_innerContext.CurrentUtcDateTime);
+            }
+        }
 
         /// <inheritdoc/>
         public override void ContinueAsNew(object input)
         {
-            UpdateInnerProperties();
+            PreUpdateProperties();
             _innerContext.ContinueAsNew(input);
+            PostUpdateProperties();
         }
 
         /// <inheritdoc/>
         public override void ContinueAsNew(string newVersion, object input)
         {
-            UpdateInnerProperties();
+            PreUpdateProperties();
             _innerContext.ContinueAsNew(newVersion, input);
+            PostUpdateProperties();
         }
 
         /// <inheritdoc/>
         public override Task<T> CreateSubOrchestrationInstance<T>(string name, string version, object input)
         {
-            UpdateInnerProperties();
-            return _innerContext.CreateSubOrchestrationInstance<T>(name, version, input);
+            PreUpdateProperties();
+            return WrapAsync(_innerContext.CreateSubOrchestrationInstance<T>(name, version, input));
         }
 
         /// <inheritdoc/>
         public override Task<T> CreateSubOrchestrationInstance<T>(
             string name, string version, string instanceId, object input)
         {
-            UpdateInnerProperties();
-            return _innerContext.CreateSubOrchestrationInstance<T>(name, version, instanceId, input);
+            PreUpdateProperties();
+            return WrapAsync(_innerContext.CreateSubOrchestrationInstance<T>(
+                name, version, instanceId, input));
         }
 
         /// <inheritdoc/>
         public override Task<T> CreateSubOrchestrationInstance<T>(
             string name, string version, string instanceId, object input, IDictionary<string, string> tags)
         {
-            UpdateInnerProperties();
-            return _innerContext.CreateSubOrchestrationInstance<T>(name, version, instanceId, input, tags);
+            PreUpdateProperties();
+            return WrapAsync(_innerContext.CreateSubOrchestrationInstance<T>(
+                name, version, instanceId, input, tags));
         }
 
         /// <inheritdoc/>
         public override Task<T> CreateTimer<T>(DateTime fireAt, T state)
         {
-            UpdateInnerProperties();
-            return _innerContext.CreateTimer(fireAt, state);
+            PreUpdateProperties();
+            return WrapAsync(_innerContext.CreateTimer(fireAt, state));
         }
 
         /// <inheritdoc/>
         public override Task<T> CreateTimer<T>(DateTime fireAt, T state, CancellationToken cancelToken)
         {
-            UpdateInnerProperties();
-            return _innerContext.CreateTimer(fireAt, state, cancelToken);
+            PreUpdateProperties();
+            return WrapAsync(_innerContext.CreateTimer(fireAt, state, cancelToken));
         }
 
         /// <inheritdoc/>
         public override Task<TResult> ScheduleTask<TResult>(string name, string version, params object[] parameters)
         {
-            UpdateInnerProperties();
-            return _innerContext.ScheduleTask<TResult>(name, version, parameters);
+            PreUpdateProperties();
+            return Wrap(_innerContext.ScheduleTask<TResult>(name, version, parameters));
         }
 
         /// <inheritdoc/>
         public override void SendEvent(OrchestrationInstance orchestrationInstance, string eventName, object eventData)
         {
-            UpdateInnerProperties();
+            PreUpdateProperties();
             _innerContext.SendEvent(orchestrationInstance, eventName, eventData);
+            PostUpdateProperties();
         }
 
         /// <inheritdoc/>
         public override Task<TResult> ScheduleTask<TResult>(Type activityType, params object[] parameters)
         {
-            UpdateInnerProperties();
-            return ScheduleTask<TResult>(
+            PreUpdateProperties();
+            return WrapAsync(ScheduleTask<TResult>(
                 TypeShortName.ToString(activityType, includeTopAssembly: false),
                 NameVersionHelper.GetDefaultVersion(activityType),
-                parameters);
+                parameters));
         }
 
         /// <inheritdoc/>
         public override Task<T> ScheduleWithRetry<T>(
             Type taskActivityType, RetryOptions retryOptions, params object[] parameters)
         {
-            UpdateInnerProperties();
-            return ScheduleWithRetry<T>(
+            PreUpdateProperties();
+            return WrapAsync(ScheduleWithRetry<T>(
                 TypeShortName.ToString(taskActivityType, includeTopAssembly: false),
                 NameVersionHelper.GetDefaultVersion(taskActivityType),
                 retryOptions,
-                parameters);
+                parameters));
         }
 
         /// <inheritdoc/>
         public override Task<T> CreateSubOrchestrationInstance<T>(Type orchestrationType, object input)
         {
-            UpdateInnerProperties();
-            return CreateSubOrchestrationInstance<T>(
+            PreUpdateProperties();
+            return WrapAsync(CreateSubOrchestrationInstance<T>(
                 TypeShortName.ToString(orchestrationType, includeTopAssembly: false),
                 NameVersionHelper.GetDefaultVersion(orchestrationType),
-                input);
+                input));
         }
 
         /// <inheritdoc/>
         public override Task<T> CreateSubOrchestrationInstance<T>(
             Type orchestrationType, string instanceId, object input)
         {
-            UpdateInnerProperties();
-            return CreateSubOrchestrationInstance<T>(
+            PreUpdateProperties();
+            return WrapAsync(CreateSubOrchestrationInstance<T>(
                 TypeShortName.ToString(orchestrationType, includeTopAssembly: false),
                 NameVersionHelper.GetDefaultVersion(orchestrationType),
                 instanceId,
-                input);
+                input));
         }
 
         /// <inheritdoc/>
         public override Task<T> CreateSubOrchestrationInstanceWithRetry<T>(
             Type orchestrationType, RetryOptions retryOptions, object input)
         {
-            UpdateInnerProperties();
-            return CreateSubOrchestrationInstanceWithRetry<T>(
+            PreUpdateProperties();
+            return WrapAsync(CreateSubOrchestrationInstanceWithRetry<T>(
                 TypeShortName.ToString(orchestrationType, includeTopAssembly: false),
                 NameVersionHelper.GetDefaultVersion(orchestrationType),
                 retryOptions,
-                input);
+                input));
         }
 
         /// <inheritdoc/>
         public override Task<T> CreateSubOrchestrationInstanceWithRetry<T>(
             Type orchestrationType, string instanceId, RetryOptions retryOptions, object input)
         {
-            UpdateInnerProperties();
-            return CreateSubOrchestrationInstanceWithRetry<T>(
+            PreUpdateProperties();
+            return WrapAsync(CreateSubOrchestrationInstanceWithRetry<T>(
                 TypeShortName.ToString(orchestrationType, includeTopAssembly: false),
                 NameVersionHelper.GetDefaultVersion(orchestrationType),
                 instanceId,
                 retryOptions,
-                input);
+                input));
         }
 
         /// <inheritdoc/>
         public override T CreateClient<T>()
         {
-            UpdateInnerProperties();
-            return _innerContext.CreateClient<T>();
+            PreUpdateProperties();
+            return Wrap(_innerContext.CreateClient<T>());
         }
 
         /// <inheritdoc/>
         public override T CreateClient<T>(bool useFullyQualifiedMethodNames)
         {
-            UpdateInnerProperties();
-            return _innerContext.CreateClient<T>(useFullyQualifiedMethodNames);
+            PreUpdateProperties();
+            return Wrap(_innerContext.CreateClient<T>(useFullyQualifiedMethodNames));
         }
 
         /// <inheritdoc/>
         public override T CreateRetryableClient<T>(RetryOptions retryOptions)
         {
-            UpdateInnerProperties();
-            return _innerContext.CreateRetryableClient<T>(retryOptions);
+            PreUpdateProperties();
+            return Wrap(_innerContext.CreateRetryableClient<T>(retryOptions));
         }
 
         /// <inheritdoc/>
         public override T CreateRetryableClient<T>(RetryOptions retryOptions, bool useFullyQualifiedMethodNames)
         {
-            UpdateInnerProperties();
-            return _innerContext.CreateRetryableClient<T>(retryOptions, useFullyQualifiedMethodNames);
+            PreUpdateProperties();
+            return Wrap(_innerContext.CreateRetryableClient<T>(retryOptions, useFullyQualifiedMethodNames));
         }
 
         /// <inheritdoc/>
         public override Task<T> CreateSubOrchestrationInstanceWithRetry<T>(
             string name, string version, RetryOptions retryOptions, object input)
         {
-            UpdateInnerProperties();
-            return _innerContext.CreateSubOrchestrationInstanceWithRetry<T>(name, version, retryOptions, input);
+            PreUpdateProperties();
+            return WrapAsync(_innerContext.CreateSubOrchestrationInstanceWithRetry<T>(
+                name, version, retryOptions, input));
         }
 
         /// <inheritdoc/>
         public override Task<T> CreateSubOrchestrationInstanceWithRetry<T>(
             string name, string version, string instanceId, RetryOptions retryOptions, object input)
         {
-            UpdateInnerProperties();
-            return _innerContext.CreateSubOrchestrationInstanceWithRetry<T>(
-                name, version, instanceId, retryOptions, input);
+            PreUpdateProperties();
+            return WrapAsync(_innerContext.CreateSubOrchestrationInstanceWithRetry<T>(
+                name, version, instanceId, retryOptions, input));
         }
 
-        private void UpdateInnerProperties()
+        private async Task<T> WrapAsync<T>(Task<T> task)
+        {
+            T result = await task;
+            PostUpdateProperties();
+            return result;
+        }
+
+        private T Wrap<T>(T result)
+        {
+            PostUpdateProperties();
+            return result;
+        }
+
+        private void PreUpdateProperties()
         {
             // We have no way to hook in to the public setter of these properties to also set it on the wrapped context.
             // Instead, we will have to update these properties on *every* call to the wrapped context, to ensure it is
             // up to date.
             _innerContext.ErrorDataConverter = ErrorDataConverter;
             _innerContext.MessageDataConverter = MessageDataConverter;
+        }
+
+        private void PostUpdateProperties()
+        {
+            IsReplaying = _innerContext.IsReplaying;
         }
     }
 }

--- a/src/DurableTask.DependencyInjection/src/Orchestrations/WrapperOrchestrationContext.cs
+++ b/src/DurableTask.DependencyInjection/src/Orchestrations/WrapperOrchestrationContext.cs
@@ -60,7 +60,7 @@ namespace DurableTask.DependencyInjection.Orchestrations
         public override Task<T> CreateSubOrchestrationInstance<T>(string name, string version, object input)
         {
             PreUpdateProperties();
-            return WrapAsync(_innerContext.CreateSubOrchestrationInstance<T>(name, version, input));
+            return Wrap(_innerContext.CreateSubOrchestrationInstance<T>(name, version, input));
         }
 
         /// <inheritdoc/>
@@ -68,7 +68,7 @@ namespace DurableTask.DependencyInjection.Orchestrations
             string name, string version, string instanceId, object input)
         {
             PreUpdateProperties();
-            return WrapAsync(_innerContext.CreateSubOrchestrationInstance<T>(
+            return Wrap(_innerContext.CreateSubOrchestrationInstance<T>(
                 name, version, instanceId, input));
         }
 
@@ -77,7 +77,7 @@ namespace DurableTask.DependencyInjection.Orchestrations
             string name, string version, string instanceId, object input, IDictionary<string, string> tags)
         {
             PreUpdateProperties();
-            return WrapAsync(_innerContext.CreateSubOrchestrationInstance<T>(
+            return Wrap(_innerContext.CreateSubOrchestrationInstance<T>(
                 name, version, instanceId, input, tags));
         }
 
@@ -85,14 +85,14 @@ namespace DurableTask.DependencyInjection.Orchestrations
         public override Task<T> CreateTimer<T>(DateTime fireAt, T state)
         {
             PreUpdateProperties();
-            return WrapAsync(_innerContext.CreateTimer(fireAt, state));
+            return Wrap(_innerContext.CreateTimer(fireAt, state));
         }
 
         /// <inheritdoc/>
         public override Task<T> CreateTimer<T>(DateTime fireAt, T state, CancellationToken cancelToken)
         {
             PreUpdateProperties();
-            return WrapAsync(_innerContext.CreateTimer(fireAt, state, cancelToken));
+            return Wrap(_innerContext.CreateTimer(fireAt, state, cancelToken));
         }
 
         /// <inheritdoc/>
@@ -114,7 +114,7 @@ namespace DurableTask.DependencyInjection.Orchestrations
         public override Task<TResult> ScheduleTask<TResult>(Type activityType, params object[] parameters)
         {
             PreUpdateProperties();
-            return WrapAsync(ScheduleTask<TResult>(
+            return Wrap(ScheduleTask<TResult>(
                 TypeShortName.ToString(activityType, includeTopAssembly: false),
                 NameVersionHelper.GetDefaultVersion(activityType),
                 parameters));
@@ -125,7 +125,7 @@ namespace DurableTask.DependencyInjection.Orchestrations
             Type taskActivityType, RetryOptions retryOptions, params object[] parameters)
         {
             PreUpdateProperties();
-            return WrapAsync(ScheduleWithRetry<T>(
+            return Wrap(ScheduleWithRetry<T>(
                 TypeShortName.ToString(taskActivityType, includeTopAssembly: false),
                 NameVersionHelper.GetDefaultVersion(taskActivityType),
                 retryOptions,
@@ -133,10 +133,18 @@ namespace DurableTask.DependencyInjection.Orchestrations
         }
 
         /// <inheritdoc/>
+        public override Task<T> ScheduleWithRetry<T>(
+            string name, string version, RetryOptions retryOptions, params object[] parameters)
+        {
+            PreUpdateProperties();
+            return Wrap(_innerContext.ScheduleWithRetry<T>(name, version, retryOptions, parameters));
+        }
+
+        /// <inheritdoc/>
         public override Task<T> CreateSubOrchestrationInstance<T>(Type orchestrationType, object input)
         {
             PreUpdateProperties();
-            return WrapAsync(CreateSubOrchestrationInstance<T>(
+            return Wrap(CreateSubOrchestrationInstance<T>(
                 TypeShortName.ToString(orchestrationType, includeTopAssembly: false),
                 NameVersionHelper.GetDefaultVersion(orchestrationType),
                 input));
@@ -147,7 +155,7 @@ namespace DurableTask.DependencyInjection.Orchestrations
             Type orchestrationType, string instanceId, object input)
         {
             PreUpdateProperties();
-            return WrapAsync(CreateSubOrchestrationInstance<T>(
+            return Wrap(CreateSubOrchestrationInstance<T>(
                 TypeShortName.ToString(orchestrationType, includeTopAssembly: false),
                 NameVersionHelper.GetDefaultVersion(orchestrationType),
                 instanceId,
@@ -159,7 +167,7 @@ namespace DurableTask.DependencyInjection.Orchestrations
             Type orchestrationType, RetryOptions retryOptions, object input)
         {
             PreUpdateProperties();
-            return WrapAsync(CreateSubOrchestrationInstanceWithRetry<T>(
+            return Wrap(CreateSubOrchestrationInstanceWithRetry<T>(
                 TypeShortName.ToString(orchestrationType, includeTopAssembly: false),
                 NameVersionHelper.GetDefaultVersion(orchestrationType),
                 retryOptions,
@@ -171,7 +179,7 @@ namespace DurableTask.DependencyInjection.Orchestrations
             Type orchestrationType, string instanceId, RetryOptions retryOptions, object input)
         {
             PreUpdateProperties();
-            return WrapAsync(CreateSubOrchestrationInstanceWithRetry<T>(
+            return Wrap(CreateSubOrchestrationInstanceWithRetry<T>(
                 TypeShortName.ToString(orchestrationType, includeTopAssembly: false),
                 NameVersionHelper.GetDefaultVersion(orchestrationType),
                 instanceId,
@@ -212,7 +220,7 @@ namespace DurableTask.DependencyInjection.Orchestrations
             string name, string version, RetryOptions retryOptions, object input)
         {
             PreUpdateProperties();
-            return WrapAsync(_innerContext.CreateSubOrchestrationInstanceWithRetry<T>(
+            return Wrap(_innerContext.CreateSubOrchestrationInstanceWithRetry<T>(
                 name, version, retryOptions, input));
         }
 
@@ -221,11 +229,11 @@ namespace DurableTask.DependencyInjection.Orchestrations
             string name, string version, string instanceId, RetryOptions retryOptions, object input)
         {
             PreUpdateProperties();
-            return WrapAsync(_innerContext.CreateSubOrchestrationInstanceWithRetry<T>(
+            return Wrap(_innerContext.CreateSubOrchestrationInstanceWithRetry<T>(
                 name, version, instanceId, retryOptions, input));
         }
 
-        private async Task<T> WrapAsync<T>(Task<T> task)
+        private async Task<T> Wrap<T>(Task<T> task)
         {
             T result = await task;
             PostUpdateProperties();

--- a/src/DurableTask.DependencyInjection/test/Orchestrations/WrapperOrchestrationContextTests.cs
+++ b/src/DurableTask.DependencyInjection/test/Orchestrations/WrapperOrchestrationContextTests.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Jacob Viau. All rights reserved.
+// Licensed under the APACHE 2.0. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using DurableTask.Core;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace DurableTask.DependencyInjection.Orchestrations.Tests
+{
+    public class WrapperOrchestrationContextTests
+    {
+        [Fact]
+        public async Task IsReplaying_Synced()
+        {
+            static object GetDefault(ParameterInfo parameter)
+            {
+                if (parameter.ParameterType == typeof(string))
+                {
+                    return string.Empty;
+                }
+
+                if (parameter.ParameterType == typeof(Type))
+                {
+                    return typeof(object);
+                }
+
+                return null;
+            }
+
+            foreach (MethodInfo method in typeof(WrapperOrchestrationContext).GetMethods())
+            {
+                if (!typeof(Task).IsAssignableFrom(method.ReturnType))
+                {
+                    continue;
+                }
+
+                var inner = new Mock<OrchestrationContext>();
+                SetIsReplaying(inner.Object, true);
+                var tcs = new TaskCompletionSource<object>();
+                inner.SetReturnsDefault(tcs.Task);
+                var context = new WrapperOrchestrationContext(inner.Object);
+
+                MethodInfo toInvoke = method.IsGenericMethodDefinition
+                    ? method.MakeGenericMethod(typeof(object)) : method;
+                object[] parameters = toInvoke.GetParameters().Select(GetDefault).ToArray();
+                var task = (Task)toInvoke.Invoke(context, parameters);
+
+                context.IsReplaying.Should().BeTrue();
+                SetIsReplaying(inner.Object, false);
+                tcs.SetResult(null);
+
+                await task;
+                context.IsReplaying.Should().BeFalse();
+            }
+        }
+
+        private static void SetIsReplaying(OrchestrationContext context, bool isReplaying)
+        {
+            typeof(OrchestrationContext).GetProperty("IsReplaying").SetValue(context, isReplaying);
+        }
+    }
+}


### PR DESCRIPTION
Due to `OrchestrationContext` not having several properties as virtual, the wrapper context is unable to easily reflect state changes to the inner context. To resolve this, we wrap _every_ call we can override to do a pre and post property update. However, for async tasks we need to ensure the inner task is complete before updating properties.

Fixes #19 