### PR TITLE
Enable instrumentation via IHostApplicationBuilder

### DIFF
--- a/samples/DurableTask.Extensions.Samples/Program.cs
+++ b/samples/DurableTask.Extensions.Samples/Program.cs
@@ -10,24 +10,23 @@ using DurableTask.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-IHost host = Host.CreateDefaultBuilder(args)
-    .ConfigureServices(services =>
-    {
-        // Can register DataConvert in service container, or in options below.
-        // services.AddSingleton<DataConverter>(new StjDataConverter());
-        services.AddSingleton<IConsole, ConsoleWrapper>();
-        services.AddHostedService<TaskEnqueuer>();
-    })
-    .ConfigureTaskHubWorker((context, builder) =>
-    {
-        builder.WithOrchestrationService(new LocalOrchestrationService());
-        builder.AddDurableExtensions(opt => opt.DataConverter = new StjDataConverter());
-        builder.AddClient();
-        builder.AddOrchestrationsFromAssembly<GreetingsOrchestration>(includePrivate: true);
-        builder.AddActivitiesFromAssembly<GreetingsOrchestration>(includePrivate: true);
-    })
-    .UseConsoleLifetime()
-    .Build();
+HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
+
+// Can register DataConvert in service container, or in options below.
+// builder.Services.AddSingleton<DataConverter>(new StjDataConverter());
+builder.Services.AddSingleton<IConsole, ConsoleWrapper>();
+builder.Services.AddHostedService<TaskEnqueuer>();
+
+builder.ConfigureTaskHubWorker((context, builder) =>
+{
+    builder.WithOrchestrationService(new LocalOrchestrationService());
+    builder.AddDurableExtensions(opt => opt.DataConverter = new StjDataConverter());
+    builder.AddClient();
+    builder.AddOrchestrationsFromAssembly<GreetingsOrchestration>(includePrivate: true);
+    builder.AddActivitiesFromAssembly<GreetingsOrchestration>(includePrivate: true);
+});
+
+IHost host = builder.Build();
 
 await host.RunAsync();
 

--- a/samples/DurableTask.Instrumentation.Samples/Program.cs
+++ b/samples/DurableTask.Instrumentation.Samples/Program.cs
@@ -22,23 +22,22 @@ using TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
     .AddZipkinExporter()
     .Build();
 
-IHost host = Host.CreateDefaultBuilder(args)
-    .ConfigureServices(services =>
-    {
-        services.AddSingleton<IConsole, ConsoleWrapper>();
-        services.AddHostedService<TaskEnqueuer>();
-    })
-    .ConfigureTaskHubWorker((context, builder) =>
-    {
-        builder.WithOrchestrationService(GetOrchestrationService());
-        builder.AddDurableExtensions();
-        builder.AddDurableInstrumentation();
-        builder.AddClient();
-        builder.AddOrchestrationsFromAssembly<TopOrchestration>(includePrivate: true);
-        builder.AddActivitiesFromAssembly<TopOrchestration>(includePrivate: true);
-    })
-    .UseConsoleLifetime()
-    .Build();
+HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.AddSingleton<IConsole, ConsoleWrapper>();
+builder.Services.AddHostedService<TaskEnqueuer>();
+
+builder.ConfigureTaskHubWorker((context, builder) =>
+{
+    builder.WithOrchestrationService(GetOrchestrationService());
+    builder.AddDurableExtensions();
+    builder.AddDurableInstrumentation();
+    builder.AddClient();
+    builder.AddOrchestrationsFromAssembly<TopOrchestration>(includePrivate: true);
+    builder.AddActivitiesFromAssembly<TopOrchestration>(includePrivate: true);
+});
+    
+IHost host = builder.Build();
 
 await host.RunAsync();
 

--- a/samples/DurableTask.Samples/Program.cs
+++ b/samples/DurableTask.Samples/Program.cs
@@ -26,32 +26,32 @@ public class Program
     /// <returns>A task that completes when this program is finished running.</returns>
     public static Task Main(string[] args)
     {
-        IHost host = Host.CreateDefaultBuilder(args)
-            .ConfigureAppConfiguration(builder => builder.AddUserSecrets<Program>())
-            .ConfigureServices(services =>
-            {
-                services.Configure<TaskHubOptions>(opt =>
-                {
-                    opt.CreateIfNotExists = true;
-                });
-                services.AddSingleton<IConsole, ConsoleWrapper>();
-                services.AddHostedService<TaskEnqueuer>();
-                services.AddSingleton(UseLocalEmulator());
-            })
-            .ConfigureTaskHubWorker((context, builder) =>
-            {
-                builder.AddClient();
-                builder.UseOrchestrationMiddleware<SampleMiddleware>();
-                builder.UseActivityMiddleware<SampleMiddleware>();
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
 
-                builder
-                    .AddOrchestration<GreetingsOrchestration>()
-                    .AddOrchestration<GenericOrchestrationRunner>();
+        builder.Configuration.AddUserSecrets<Program>();
 
-                builder.AddActivitiesFromAssembly<Program>();
-            })
-            .UseConsoleLifetime()
-            .Build();
+        builder.Services.Configure<TaskHubOptions>(opt =>
+        {
+            opt.CreateIfNotExists = true;
+        });
+        builder.Services.AddSingleton<IConsole, ConsoleWrapper>();
+        builder.Services.AddHostedService<TaskEnqueuer>();
+        builder.Services.AddSingleton(UseLocalEmulator());
+
+        builder.ConfigureTaskHubWorker((context, builder) =>
+        {
+            builder.AddClient();
+            builder.UseOrchestrationMiddleware<SampleMiddleware>();
+            builder.UseActivityMiddleware<SampleMiddleware>();
+
+            builder
+                .AddOrchestration<GreetingsOrchestration>()
+                .AddOrchestration<GenericOrchestrationRunner>();
+
+            builder.AddActivitiesFromAssembly<Program>();
+        });
+
+        IHost host = builder.Build();
 
         return host.RunAsync();
     }

--- a/src/DurableTask.Hosting/src/Extensions/TaskHubHostBuilderExtensions.cs
+++ b/src/DurableTask.Hosting/src/Extensions/TaskHubHostBuilderExtensions.cs
@@ -33,6 +33,21 @@ public static class TaskHubHostBuilderExtensions
     /// </summary>
     /// <param name="builder">The host builder, not null.</param>
     /// <param name="configure">The action to configure the worker, not null.</param>
+    /// <returns>The original host builder with task hub worker configured.</returns>
+    public static IHostApplicationBuilder ConfigureTaskHubWorker(
+        this IHostApplicationBuilder builder, Action<ITaskHubWorkerBuilder> configure)
+    {
+        Check.NotNull(builder);
+        Check.NotNull(configure);
+
+        return builder.ConfigureTaskHubWorker(configure, _ => { });
+    }
+
+    /// <summary>
+    /// Configures the task hub worker background service.
+    /// </summary>
+    /// <param name="builder">The host builder, not null.</param>
+    /// <param name="configure">The action to configure the worker, not null.</param>
     /// <param name="configureOptions">The action to configure the task hub host options.</param>
     /// <returns>The original host builder with task hub worker configured.</returns>
     public static IHostBuilder ConfigureTaskHubWorker(
@@ -52,9 +67,42 @@ public static class TaskHubHostBuilderExtensions
     /// </summary>
     /// <param name="builder">The host builder, not null.</param>
     /// <param name="configure">The action to configure the worker, not null.</param>
+    /// <param name="configureOptions">The action to configure the task hub host options.</param>
+    /// <returns>The original host builder with task hub worker configured.</returns>
+    public static IHostApplicationBuilder ConfigureTaskHubWorker(
+        this IHostApplicationBuilder builder,
+        Action<ITaskHubWorkerBuilder> configure,
+        Action<TaskHubOptions> configureOptions)
+    {
+        Check.NotNull(builder);
+        Check.NotNull(configure);
+        Check.NotNull(configureOptions);
+
+        return builder.ConfigureTaskHubWorker((_, b) => configure(b), configureOptions);
+    }
+
+    /// <summary>
+    /// Configures the task hub worker background service.
+    /// </summary>
+    /// <param name="builder">The host builder, not null.</param>
+    /// <param name="configure">The action to configure the worker, not null.</param>
     /// <returns>The original host builder with task hub worker configured.</returns>
     public static IHostBuilder ConfigureTaskHubWorker(
         this IHostBuilder builder, Action<HostBuilderContext, ITaskHubWorkerBuilder> configure)
+    {
+        Check.NotNull(builder);
+        Check.NotNull(configure);
+        return builder.ConfigureTaskHubWorker(configure, _ => { });
+    }
+
+    /// <summary>
+    /// Configures the task hub worker background service.
+    /// </summary>
+    /// <param name="builder">The host builder, not null.</param>
+    /// <param name="configure">The action to configure the worker, not null.</param>
+    /// <returns>The original host builder with task hub worker configured.</returns>
+    public static IHostApplicationBuilder ConfigureTaskHubWorker(
+        this IHostApplicationBuilder builder, Action<IHostApplicationBuilder, ITaskHubWorkerBuilder> configure)
     {
         Check.NotNull(builder);
         Check.NotNull(configure);
@@ -90,6 +138,36 @@ public static class TaskHubHostBuilderExtensions
             services.AddTaskHubWorker(taskHubBuilder => configure(context, taskHubBuilder));
             services.AddHostedService<TaskHubBackgroundService>();
         });
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the task hub worker background service.
+    /// </summary>
+    /// <param name="builder">The host builder, not null.</param>
+    /// <param name="configure">The action to configure the worker, not null.</param>
+    /// <param name="configureOptions">The action to configure the task hub host options.</param>
+    /// <returns>The original host builder with task hub worker configured.</returns>
+    public static IHostApplicationBuilder ConfigureTaskHubWorker(
+        this IHostApplicationBuilder builder,
+        Action<IHostApplicationBuilder, ITaskHubWorkerBuilder> configure,
+        Action<TaskHubOptions> configureOptions)
+    {
+        Check.NotNull(builder);
+        Check.NotNull(configure);
+        Check.NotNull(configureOptions);
+
+        builder.Services.AddOptions();
+        builder.Services.AddLogging();
+
+        builder.Services
+            .AddOptions<TaskHubOptions>()
+            .Bind(builder.Configuration.GetSection("TaskHub"))
+            .Configure(configureOptions);
+
+        builder.Services.AddTaskHubWorker(taskHubBuilder => configure(builder, taskHubBuilder));
+        builder.Services.AddHostedService<TaskHubBackgroundService>();
 
         return builder;
     }

--- a/src/DurableTask.Hosting/src/Extensions/TaskHubHostBuilderExtensions.cs
+++ b/src/DurableTask.Hosting/src/Extensions/TaskHubHostBuilderExtensions.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Hosting;
 namespace DurableTask.Hosting;
 
 /// <summary>
-/// Extensions for configuring a task hub worker service on <see cref="IHostBuilder"/>.
+/// Extensions for configuring a task hub worker service on <see cref="IHostBuilder"/> or <see cref="IHostApplicationBuilder"/>.
 /// </summary>
 public static class TaskHubHostBuilderExtensions
 {

--- a/src/DurableTask.Hosting/test/Extensions/TaskHubHostBuilderExtensionsTests.cs
+++ b/src/DurableTask.Hosting/test/Extensions/TaskHubHostBuilderExtensionsTests.cs
@@ -12,33 +12,55 @@ namespace DurableTask.Hosting.Extensions.Tests;
 public class TaskHubHostBuilderExtensionsTests
 {
     [Fact]
-    public void ConfigureTaskHubWorker_ArgumentNullBuilder()
+    public void Configure_HostBuilder_TaskHubWorker_ArgumentNullBuilder()
         => RunTestException<ArgumentNullException>(
-            builder => TaskHubHostBuilderExtensions
-                .ConfigureTaskHubWorker(null, b => { }));
+            (IHostBuilder builder) => TaskHubHostBuilderExtensions
+                .ConfigureTaskHubWorker((IHostBuilder)null, b => { }));
     [Fact]
-    public void ConfigureTaskHubWorker_ArgumentNullConfigure()
+    public void Configure_HostApplicationBuilder_TaskHubWorker_ArgumentNullBuilder()
         => RunTestException<ArgumentNullException>(
-            builder => TaskHubHostBuilderExtensions
+            (IHostApplicationBuilder builder) => TaskHubHostBuilderExtensions
+                .ConfigureTaskHubWorker((IHostApplicationBuilder)null, b => { }));
+    [Fact]
+    public void Configure_HostBuilder_TaskHubWorker_ArgumentNullConfigure()
+        => RunTestException<ArgumentNullException>(
+            (IHostBuilder builder) => TaskHubHostBuilderExtensions
                 .ConfigureTaskHubWorker(builder, (Action<ITaskHubWorkerBuilder>)null));
 
     [Fact]
-    public void ConfigureTaskHubWorker_ArgumentNullBuilder2()
+    public void Configure_HostApplicationBuilder_TaskHubWorker_ArgumentNullConfigure()
         => RunTestException<ArgumentNullException>(
-            builder => TaskHubHostBuilderExtensions
-                .ConfigureTaskHubWorker(null, (c, b)  => { }));
-    [Fact]
-    public void ConfigureTaskHubWorker_ArgumentNullConfigure2()
-        => RunTestException<ArgumentNullException>(
-            builder => TaskHubHostBuilderExtensions
-                .ConfigureTaskHubWorker(builder, (Action<HostBuilderContext, ITaskHubWorkerBuilder>)null));
+            (IHostApplicationBuilder builder) => TaskHubHostBuilderExtensions
+                .ConfigureTaskHubWorker(builder, (Action<ITaskHubWorkerBuilder>)null));
 
     [Fact]
-    public void ConfigureTaskHubWorker_Callback()
+    public void Configure_HostBuilder_TaskHubWorker_ArgumentNullBuilder2()
+        => RunTestException<ArgumentNullException>(
+            (IHostBuilder builder) => TaskHubHostBuilderExtensions
+                .ConfigureTaskHubWorker((IHostBuilder)null, (c, b) => { }));
+    [Fact]
+    public void Configure_HostApplicationBuilder_TaskHubWorker_ArgumentNullBuilder2()
+        => RunTestException<ArgumentNullException>(
+            (IHostApplicationBuilder builder) => TaskHubHostBuilderExtensions
+                .ConfigureTaskHubWorker((IHostApplicationBuilder)null, (c, b) => { }));
+
+    [Fact]
+    public void Configure_HostBuilder_TaskHubWorker_ArgumentNullConfigure2()
+        => RunTestException<ArgumentNullException>(
+            (IHostBuilder builder) => TaskHubHostBuilderExtensions
+                .ConfigureTaskHubWorker(builder, (Action<HostBuilderContext, ITaskHubWorkerBuilder>)null));
+    [Fact]
+    public void Configure_HostApplicationBuilder_TaskHubWorker_ArgumentNullConfigure2()
+        => RunTestException<ArgumentNullException>(
+            (IHostApplicationBuilder builder) => TaskHubHostBuilderExtensions
+                .ConfigureTaskHubWorker(builder, (Action<IHostApplicationBuilder, ITaskHubWorkerBuilder>)null));
+
+    [Fact]
+    public void Configure_HostBuilder_TaskHubWorker_Callback()
     {
         ITaskHubWorkerBuilder capturedBuilder = null;
         RunTest(
-            builder => builder.ConfigureTaskHubWorker(b => capturedBuilder = b),
+            (IHostBuilder builder) => builder.ConfigureTaskHubWorker(b => capturedBuilder = b),
             (builder, returned) =>
             {
                 returned.Should().BeSameAs(builder);
@@ -47,12 +69,44 @@ public class TaskHubHostBuilderExtensionsTests
     }
 
     [Fact]
-    public void ConfigureTaskHubWorker_Callback2()
+    public void Configure_HostApplicationBuilder_TaskHubWorker_Callback()
+    {
+        ITaskHubWorkerBuilder capturedBuilder = null;
+        RunTest(
+            (IHostApplicationBuilder builder) => builder.ConfigureTaskHubWorker(b => capturedBuilder = b),
+            (builder, returned) =>
+            {
+                returned.Should().BeSameAs(builder);
+                capturedBuilder.Should().NotBeNull();
+            });
+    }
+
+    [Fact]
+    public void Configure_HostBuilder_TaskHubWorker_Callback2()
     {
         HostBuilderContext capturedContext = null;
         ITaskHubWorkerBuilder capturedBuilder = null;
         RunTest(
-            builder => builder.ConfigureTaskHubWorker((c, b) =>
+            (IHostBuilder builder) => builder.ConfigureTaskHubWorker((c, b) =>
+            {
+                capturedContext = c;
+                capturedBuilder = b;
+            }),
+            (builder, returned) =>
+            {
+                returned.Should().BeSameAs(builder);
+                capturedContext.Should().NotBeNull();
+                capturedBuilder.Should().NotBeNull();
+            });
+    }
+
+    [Fact]
+    public void Configure_HostApplicationBuilder_TaskHubWorker_Callback2()
+    {
+        IHostApplicationBuilder capturedContext = null;
+        ITaskHubWorkerBuilder capturedBuilder = null;
+        RunTest(
+            (IHostApplicationBuilder builder) => builder.ConfigureTaskHubWorker((c, b) =>
             {
                 capturedContext = c;
                 capturedBuilder = b;
@@ -78,11 +132,35 @@ public class TaskHubHostBuilderExtensionsTests
         exception.Should().NotBeNull();
     }
 
+    private static void RunTestException<TException>(Action<IHostApplicationBuilder> act)
+        where TException : Exception
+    {
+        bool Act(IHostApplicationBuilder builder)
+        {
+            act(builder);
+            return true;
+        }
+
+        TException exception = Capture<TException>(() => RunTest(Act, null));
+        exception.Should().NotBeNull();
+    }
+
     private static void RunTest<TResult>(
         Func<IHostBuilder, TResult> act,
         Action<IHostBuilder, TResult> verify)
     {
         HostBuilder builder = new();
+
+        TResult result = act(builder);
+        builder.Build();
+        verify?.Invoke(builder, result);
+    }
+
+    private static void RunTest<TResult>(
+        Func<IHostApplicationBuilder, TResult> act,
+        Action<IHostApplicationBuilder, TResult> verify)
+    {
+        HostApplicationBuilder builder = new();
 
         TResult result = act(builder);
         builder.Build();


### PR DESCRIPTION
This PR depends on #56 . Fixes #57 by adding extra extension methods for `TaskHubHostBuilderExtensions.cs` to support `IHostApplicationBuilder`.

Tests
====

 - [x] Added extra UTs to preserve coverage
 - [x] Samples work both with in-memory and Azurite